### PR TITLE
Making it clear that a child is attached to a root

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ for more details.
 ### Child Elements
 
 Any HTML element may be assigned to an animator instance using `animator: animator-identifier` CSS
-syntax. In this case, the element is assigned as a child element to the first ancestor animator of
+syntax. In this case, the element is assigned as a child element to the first ancestor animator root of
 the given name.
 
 ***Note:*** The animator receives this in a flat list but we can also consider sending a sparse


### PR DESCRIPTION
I'm not sure if this is correct or not, so feel free to close it if it's not.  I'm presuming that a child looks up the tree for an `animator-root`, not an `animator`.
