### PR TITLE
Add example of not running animators for offscreen proxies.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -463,7 +463,9 @@ associated <a>animation request flag</a> is <a>frame-requested</a> then the the 
 
 Note: The user agent is not required to run animations on every frame. It is legal to defer
       <a>generating an animation frame<a> until a later frame. This allow the user agent to
-      provide a different service level according to their policy. 
+      provide a different service level according to their policy. For example, a user agent
+      may choose not to service an animation whose proxies will not be visible within the visual
+      viewport on the current frame.
 
 
 When the user agent wants to <dfn>run animators</dfn>, it <em>must</em> iterates over <a>animator
@@ -504,10 +506,6 @@ instance list</a> as |instance|:
 
 Note: Although inefficient, it is legal for the user agent to <a>run animators</a> multiple times 
 in the same frame.
-
-Issue: Todo: add provision that allows user agents to skip calling <a>animate</a> 
-    on any <a>animators</a> whose proxies are not within the visual viewport or whose attributes
-    are not mutated.
 
 Closing an Animator {#closing-animator}
 ====================================================


### PR DESCRIPTION
Adds an example to the note about service level that a browser may
choose not to service offscreen proxies.