### PR TITLE
Use the hash-mark to simplify value syntax.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -559,7 +559,7 @@ Two CSS properties 'animator-root' and 'animator' may be used to assign an HTML 
 
 <pre class='propdef'>
 Name: animator-root
-Value:  none | [<a>animator name</a> <a>animator slot</a>, ]* <a>animator name</a> <a>animator slot</a>
+Value:  none | [<a>animator name</a> <a>animator slot</a> ]#
 Initial: none
 Applies to: all elements
 Inherited: no
@@ -592,7 +592,7 @@ Animatable: no
 
 <pre class='propdef'>
 Name: animator
-Value:  none | [<a>animator name</a> <a>animator slot</a>, ]* <a>animator name</a> <a>animator slot</a>
+Value:  none | [<a>animator name</a> <a>animator slot</a> ]#
 Initial: none
 Applies to: all elements
 Inherited: no

--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version c4abe0090f3070a4b5855ba5c075f1e5099bbf6d" name="generator">
+  <meta content="Bikeshed version aa692b5bb18791d7660cd494994fd0ac2ec23132" name="generator">
   <link href="https://wicg.github.io/animation-worklet/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1424,12 +1424,13 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Animation Worklet API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-04-18">18 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-04-19">19 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/animation-worklet/">https://wicg.github.io/animation-worklet/</a>
      <dt>Issue Tracking:
+     <dd><a href="https://github.com/WICG/animation-worklet/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:majidvp@google.com">Majid Valipour</a>
@@ -1918,7 +1919,7 @@ in the same frame.</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-animator-root">animator-root</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-3">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-2">animator slot</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a> <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-4">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-3">animator slot</a>
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-3">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-2">animator slot</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma">#</a>
      <tr>
       <th>Initial:
       <td>none
@@ -1947,19 +1948,19 @@ in the same frame.</p>
    <dl>
     <dt><dfn class="css" data-dfn-for="animator-root" data-dfn-type="value" data-export="" id="valdef-animator-root-none">none<a class="self-link" href="#valdef-animator-root-none"></a></dfn> 
     <dd> There will be no <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-14">animator instance</a> that has this element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-3">root element</a>. 
-    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-5">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-4">animator slot</a> 
+    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-4">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-3">animator slot</a> 
     <dd>
-      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-6">animator name</a> specified in the list, the following applies for each animation frame: 
+      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-5">animator name</a> specified in the list, the following applies for each animation frame: 
      <ul>
       <li data-md="">
-       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-3">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-7">animator name</a>, the inclusion
-of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-8">animator name</a> as a value has no effect.</p>
+       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-3">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-6">animator name</a>, the inclusion
+of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-7">animator name</a> as a value has no effect.</p>
       <li data-md="">
        <p>Otherwise, an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-15">animator instance</a> with this element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-4">root element</a> will exist and will have its <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-3">animate function</a> called (with respect to the rules
 laid out in <a href="#running-animators">§8 Running Animators</a>) with an <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-6">element proxy</a> for this element passed as
-one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-7">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-5">animator slot</a>.</p>
+one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-7">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-4">animator slot</a>.</p>
      </ul>
-     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-9">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-10">animator name</a> is processed.</p>
+     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-8">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-9">animator name</a> is processed.</p>
    </dl>
    <table class="def propdef" data-link-for-hint="animator">
     <tbody>
@@ -1968,7 +1969,7 @@ one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-pro
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-animator">animator</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-11">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-6">animator slot</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a> <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-12">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-7">animator slot</a>
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-10">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-5">animator slot</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma">#</a>
      <tr>
       <th>Initial:
       <td>none
@@ -1997,18 +1998,18 @@ one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-pro
    <dl>
     <dt><dfn class="css" data-dfn-for="animator" data-dfn-type="value" data-export="" id="valdef-animator-none">none<a class="self-link" href="#valdef-animator-none"></a></dfn> 
     <dd> This element will not be passed into any <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-4">animate function</a> as one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-8">element proxies</a>. 
-    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-13">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-8">animator slot</a> 
+    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-11">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-6">animator slot</a> 
     <dd>
-      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-14">animator name</a> specified in the list, the following applies for each animation frame: 
+      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-12">animator name</a> specified in the list, the following applies for each animation frame: 
      <ul>
       <li data-md="">
-       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-4">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-15">animator name</a>, the inclusion
-of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-16">animator name</a> as a value has no effect.</p>
+       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-4">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-13">animator name</a>, the inclusion
+of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-14">animator name</a> as a value has no effect.</p>
       <li data-md="">
-       <p>Otherwise, an <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-9">element proxy</a> for this element will be passed into the <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-5">animate function</a> of the closest ancestor <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-16">animator instance</a> with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-17">animator name</a> as one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-10">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-9">animator slot</a>. If no
+       <p>Otherwise, an <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-9">element proxy</a> for this element will be passed into the <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-5">animate function</a> of the closest ancestor <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-16">animator instance</a> with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-15">animator name</a> as one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-10">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-7">animator slot</a>. If no
 such <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-17">animator instance</a> exists, one is created with the document root element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-5">root element</a>.</p>
      </ul>
-     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-18">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-19">animator name</a> is processed.</p>
+     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-16">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-17">animator name</a> is processed.</p>
    </dl>
    <h2 class="heading settled" data-level="11" id="effect-stack"><span class="secno">11. </span><span class="content">Effect Stack</span><a class="self-link" href="#effect-stack"></a></h2>
    <p class="issue" id="issue-b3b90f2d"><a class="self-link" href="#issue-b3b90f2d"></a> Todo: the animators output style values have the highest order in animation stack effect and
@@ -2022,8 +2023,8 @@ point.</p>
    <h2 class="heading settled" data-level="14" id="examples"><span class="secno">14. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <h3 class="heading settled" data-level="14.1" id="example-1"><span class="secno">14.1. </span><span class="content">Example 1: A fade-in animation with spring timing.</span><a class="self-link" href="#example-1"></a></h3>
 <pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">.</span><span class="nc">myFadein</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="s1">'spring'</span> <span class="s1">'fadein'</span><span class="p">;</span>
+<span class="nc">.myFadein</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">:</span> <span class="s1">'spring'</span> <span class="s1">'fadein'</span><span class="p">;</span>
 <span class="p">}</span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
 
@@ -2062,14 +2063,14 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
 </pre>
    <h3 class="heading settled" data-level="14.2" id="example-2"><span class="secno">14.2. </span><span class="content">Example 2: Twitter header.</span><a class="self-link" href="#example-2"></a></h3>
 <pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">#</span><span class="nn">scroller</span> <span class="p">{</span>
-  <span class="n">animator-root</span><span class="p">:</span> <span class="n">twitter-header</span><span class="p">;</span>
+<span class="nn">#scroller</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">-</span><span class="n">root</span><span class="o">:</span> <span class="n">twitter</span><span class="o">-</span><span class="n">header</span><span class="p">;</span>
 <span class="p">}</span>
-<span class="p">.</span><span class="nc">avatar</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="n">twitter-header</span> <span class="n">avatar</span><span class="p">;</span>
+<span class="nc">.avatar</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">:</span> <span class="n">twitter</span><span class="o">-</span><span class="n">header</span> <span class="n">avatar</span><span class="p">;</span>
 <span class="p">}</span>
-<span class="p">.</span><span class="nc">bar</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="n">twitter-header</span> <span class="n">bar</span><span class="p">;</span>
+<span class="nc">.bar</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">:</span> <span class="n">twitter</span><span class="o">-</span><span class="n">header</span> <span class="n">bar</span><span class="p">;</span>
 <span class="p">}</span>
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
 
@@ -2110,14 +2111,14 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
   animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
     <span class="kd">var</span> progress <span class="o">=</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span>currentTime<span class="p">;</span>
 
-    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'avatar'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
+    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'avatar'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="o">=></span> <span class="p">{</span>
       elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'transform'</span><span class="p">,</span> <span class="k">new</span> CSSTransformValue<span class="p">(</span><span class="p">[</span>
           <span class="k">new</span> CSSTranslation<span class="p">(</span><span class="k">new</span> CSSSimpleLength<span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="s1">'px'</span><span class="p">)</span><span class="p">,</span>
                              <span class="k">new</span> CSSSimpleLength<span class="p">(</span>tween<span class="p">(</span><span class="mi">140</span><span class="p">,</span> <span class="mi">45</span><span class="p">)</span><span class="p">(</span>progress<span class="p">)</span><span class="p">,</span> <span class="s1">'px'</span><span class="p">)</span><span class="p">)</span><span class="p">,</span>
           <span class="k">new</span> CSSScale<span class="p">(</span>tween<span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">)</span><span class="p">(</span>progress<span class="p">)</span><span class="p">,</span> tween<span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">)</span><span class="p">(</span>progress<span class="p">)</span><span class="p">)</span>
           <span class="p">]</span><span class="p">)</span><span class="p">)</span><span class="p">;</span>
     <span class="p">}</span><span class="p">)</span><span class="p">;</span>
-    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'bar'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
+    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'bar'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="o">=></span> <span class="p">{</span>
       elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'opacity'</span><span class="p">,</span> progress<span class="p">)</span><span class="p">;</span>
     <span class="p">}</span><span class="p">)</span><span class="p">;</span>
   <span class="p">}</span>
@@ -2131,11 +2132,11 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
 </pre>
    <h3 class="heading settled" data-level="14.3" id="example-3"><span class="secno">14.3. </span><span class="content">Example 3: Parallax backgrounds.</span><a class="self-link" href="#example-3"></a></h3>
 <pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">#</span><span class="nn">scroller</span> <span class="p">{</span>
-  <span class="n">animator-root</span><span class="p">:</span> <span class="s1">'parallax'</span><span class="p">;</span>
+<span class="nn">#scroller</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">-</span><span class="n">root</span><span class="o">:</span> <span class="s1">'parallax'</span><span class="p">;</span>
 <span class="p">}</span>
-<span class="p">.</span><span class="nc">background</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="s1">'parallax'</span> <span class="s1">'background'</span><span class="p">;</span>
+<span class="nc">.background</span> <span class="p">{</span>
+  <span class="n">animator</span><span class="o">:</span> <span class="s1">'parallax'</span> <span class="s1">'background'</span><span class="p">;</span>
 <span class="p">}</span>
 
 <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
@@ -2169,7 +2170,7 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
         <span class="c1">// read root scroller vertical scroll offset.
 </span>        <span class="kr">const</span> scrollTop <span class="o">=</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span>currentTime <span class="o">*</span> SCROLL_SIZE<span class="p">;</span>
         <span class="c1">// update parallax transform
-</span>        elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'background'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
+</span>        elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'background'</span><span class="p">)</span><span class="p">.</span>forEach<span class="p">(</span>elem <span class="o">=></span> <span class="p">{</span>
            <span class="kr">const</span> rate <span class="o">=</span> elem<span class="p">.</span>inputStyleMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'--parallax-rate'</span><span class="p">)</span> <span class="o">||</span> <span class="mf">0.2</span><span class="p">;</span>
            elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'transform'</span><span class="p">,</span> <span class="k">new</span> CSSTransformValue<span class="p">(</span><span class="p">[</span>
             <span class="k">new</span> CSSTranslation<span class="p">(</span><span class="k">new</span> CSSSimpleLength<span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="s1">'px'</span><span class="p">)</span><span class="p">,</span> <span class="k">new</span> CSSSimpleLength<span class="p">(</span>rate <span class="o">*</span> scrollTop<span class="p">,</span> <span class="s1">'px'</span><span class="p">)</span><span class="p">)</span><span class="p">]</span><span class="p">)</span><span class="p">)</span><span class="p">;</span>
@@ -2391,8 +2392,7 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
    <li>
     <a data-link-type="biblio">[css-values-3]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a>
-     <li><a href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#mult-comma">#</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
     </ul>
@@ -2474,7 +2474,7 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-animator-root">animator-root</a>
-      <td>none | [animator name animator slot, ]* animator name animator slot
+      <td>none | [animator name animator slot ]#
       <td>none
       <td>all elements
       <td>no
@@ -2485,7 +2485,7 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
       <td>as specified
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-animator">animator</a>
-      <td>none | [animator name animator slot, ]* animator name animator slot
+      <td>none | [animator name animator slot ]#
       <td>none
       <td>all elements
       <td>no
@@ -2620,7 +2620,7 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
    <b><a href="#animator-slot">#animator-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-slot-1">3. Concepts</a>
-    <li><a href="#ref-for-animator-slot-2">10. CSS Animator Notation</a> <a href="#ref-for-animator-slot-3">(2)</a> <a href="#ref-for-animator-slot-4">(3)</a> <a href="#ref-for-animator-slot-5">(4)</a> <a href="#ref-for-animator-slot-6">(5)</a> <a href="#ref-for-animator-slot-7">(6)</a> <a href="#ref-for-animator-slot-8">(7)</a> <a href="#ref-for-animator-slot-9">(8)</a>
+    <li><a href="#ref-for-animator-slot-2">10. CSS Animator Notation</a> <a href="#ref-for-animator-slot-3">(2)</a> <a href="#ref-for-animator-slot-4">(3)</a> <a href="#ref-for-animator-slot-5">(4)</a> <a href="#ref-for-animator-slot-6">(5)</a> <a href="#ref-for-animator-slot-7">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-input-property-list">
@@ -2653,7 +2653,7 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-animator-name-1">4. Registering an Animator Definition</a>
     <li><a href="#ref-for-animator-name-2">5. Creating an Animator</a>
-    <li><a href="#ref-for-animator-name-3">10. CSS Animator Notation</a> <a href="#ref-for-animator-name-4">(2)</a> <a href="#ref-for-animator-name-5">(3)</a> <a href="#ref-for-animator-name-6">(4)</a> <a href="#ref-for-animator-name-7">(5)</a> <a href="#ref-for-animator-name-8">(6)</a> <a href="#ref-for-animator-name-9">(7)</a> <a href="#ref-for-animator-name-10">(8)</a> <a href="#ref-for-animator-name-11">(9)</a> <a href="#ref-for-animator-name-12">(10)</a> <a href="#ref-for-animator-name-13">(11)</a> <a href="#ref-for-animator-name-14">(12)</a> <a href="#ref-for-animator-name-15">(13)</a> <a href="#ref-for-animator-name-16">(14)</a> <a href="#ref-for-animator-name-17">(15)</a> <a href="#ref-for-animator-name-18">(16)</a> <a href="#ref-for-animator-name-19">(17)</a>
+    <li><a href="#ref-for-animator-name-3">10. CSS Animator Notation</a> <a href="#ref-for-animator-name-4">(2)</a> <a href="#ref-for-animator-name-5">(3)</a> <a href="#ref-for-animator-name-6">(4)</a> <a href="#ref-for-animator-name-7">(5)</a> <a href="#ref-for-animator-name-8">(6)</a> <a href="#ref-for-animator-name-9">(7)</a> <a href="#ref-for-animator-name-10">(8)</a> <a href="#ref-for-animator-name-11">(9)</a> <a href="#ref-for-animator-name-12">(10)</a> <a href="#ref-for-animator-name-13">(11)</a> <a href="#ref-for-animator-name-14">(12)</a> <a href="#ref-for-animator-name-15">(13)</a> <a href="#ref-for-animator-name-16">(14)</a> <a href="#ref-for-animator-name-17">(15)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="root-element">


### PR DESCRIPTION
This is documented in (and will auto-link to)
https://drafts.csswg.org/css-values-3/#mult-comma

Also, it might be nice if you update to the current version of bikeshed; there are substantial diffs because you've been using an older version.