### PR TITLE
Update spec and remove all deprecated info

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -174,7 +174,7 @@ interface AnimationWorkletGlobalScope : WorkletGlobalScope {
             constructor(options) {
                 // Called when a new animator is instantiated.
             }
-            animate(elementMap, timelines) {
+            animate(timelines, effect) {
                 // Animation frame logic goes here.
             }
         }

--- a/index.bs
+++ b/index.bs
@@ -190,9 +190,9 @@ animation as needed by {{AnimationWorkletGlobalScope}}. It consists of:
 
  - An <dfn>animator name</dfn> <<ident>>#.
 
- - A <dfn>class constructor</dfn>.
+ - A <dfn>class constructor</dfn> which is the class <a>constructor</a>.
 
- - An <dfn>animate function</dfn>.
+ - An <dfn>animate function</dfn> which is the animate <a>function</a> callback.
 
 
 
@@ -205,15 +205,14 @@ consists of:
 
  - An <a>animation requested flag</a>.
 
- - An <dfn>animator output effect</dfn>.
+ - An <dfn>animator effect</dfn> which is an <a>animation effect</a>.
 
- - An <dfn>animator timelines list</dfn>.
+ - An <dfn>animator timelines list</dfn> which is <a>list</a> of <a>timelines</a>.
 
 
 An <dfn>worklet animation</dfn> is a <a>animation</a> in the <a>document</a> which may corresponds
-to an <a>animator instance</a> in the <a>worklet global scope</a>. It provides playback control
-and controls the lifetime of its corresponding <a>animator instance</a>. It
-consists of:
+to an <a>animator instance</a> in the worklet global scope. It controls the lifetime of its
+corresponding <a>animator instance</a> and provides playback control. It consists of:
 
  - An <a>animator name</a>.
 
@@ -227,6 +226,7 @@ Registering an Animator Definition {#registering-animator-definition}
 ============================================================
 The {{AnimationWorkletGlobalScope}} has a <dfn>animator name to animator definition map</dfn>.
 The map gets populated when {{registerAnimator(name, animatorCtor)}} is called.
+
 
 
 <div algorithm="register-animator">
@@ -266,7 +266,7 @@ When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
 </div>
 
 
-Animator Instance {#animator-instance}
+Animator Instance {#animator-instance-section}
 ======================================
 
 Creating an Animator Instance {#creating-animator-instance}
@@ -312,7 +312,7 @@ the user agent <em>must</em> run the following steps:
     6. Set the following on |animatorInstance| with:
         - <a>animator name</a> being |name|
         - <a>animation requested flag</a> being <a>frame-current</a>
-        - <a>animator output effect</a> being |effect|
+        - <a>animator effect</a> being |effect|
         - <a>animator timelines list</a> being |timelineList|
 
     7. Set the result of looking up |animationId| in |animatorInstanceMap| to
@@ -361,7 +361,7 @@ When the user agent wants to <dfn>run animators</dfn> in a given |workletGlobalS
 
   6. Let |timelines| be </a>animator timelines list</a> of |instance|.
 
-  8. Let |effect| be an <a>animator</a> of |instance|.
+  8. Let |effect| be an <a>animator effect</a> of |instance|.
 
   9. <a>Invoke</a> |animateFunction| with arguments «|timelines|, |effect|»,
         and with |instance| as the <a>callback this value</a>.
@@ -379,10 +379,10 @@ Requesting Animation Frames {#requesting-animation-frames}
 ----------------------------------------------------------
 
 Each <a>animator instance</a> has an associated <dfn>animation requested flag</dfn>. It must be
-either <dfn>frame-requested</dfn> or <dfn>frame-current</dfn>. It is initially set to <a>frame-
-current</a>. Various events, for example changes in of the animator's <a>animator timelines
-list</a>  currentTime can cause the <a>animation requested flag</a> to be set to <a>frame-
-requested</a>.
+either <dfn>frame-requested</dfn> or <dfn>frame-current</dfn>. It is initially set to
+<a>frame-current</a>. Various events, for example changes in of the animator's <a>animator
+timelines list</a>  currentTime can cause the <a>animation requested flag</a> to be set to
+<a>frame-requested</a>.
 
 [[#running-animators]] resets the <a>animation requested flag</a> on animators to
 <a>frame-current</a>.
@@ -393,6 +393,8 @@ Integration With Web Animations {#integration-web-animation}
 
 Creating an Worklet Animation {#creating-worklet-animation}
 -----------------------------------------------------------
+<!-- Big Text: TODO -->
+
 TODO:
   - add IDL for worklet animation
   - describe how constructor handles single or sequence of effects
@@ -401,24 +403,30 @@ TODO:
   - define what it means when localTime is read on this instance (i.e., we get last value synced
     from worklet scope)
 
-Issue(62): describe how constructor handles single or sequence of effects
-Issue(63): define new semantics for reverse/finish/playbackRate
+Issue(62): describe how constructor handles single or sequence of effects.
+
+Issue(63): define worklet animation appropriate semantics for reverse/finish/playbackRate.
 
 Timeline Attachment {#timeline-attachment}
 -------------------
+<!-- Big Text: TODO -->
 
-TODO
+TODO:
 
 Issue(61): Define semantics of attachment and detachment
 
 WorkletGroupEffect {#worklet-group-effect}
 ------------------
+<!-- Big Text: TODO -->
+
 TODO:
   - Add idl for worklet group effect
   - define the children start time schedule for the group effect. [Issue](https://github.com/w3c/web-animations/issues/191)
 
 WorkletAnimation timing model {#timing-model}
 ------------------------------------
+<!-- Big Text: TODO -->
+
 TODO:
  - Describe the relation of WorkletAnimation.currentTime with its timeline time
  - Describe the relation of WorkletAnimation.effect.getComputedTiming().localTime with the local time
@@ -505,7 +513,7 @@ registerAnimator('hidey-bar', class {
 
 </pre>
 
-Issue: This example uses a hypothetical 'phase' property on timeline as a way to detect when user
+Issue: This example uses a hypothetical "phase" property on timeline as a way to detect when user
 is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
 fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
 the last few frames.
@@ -568,5 +576,6 @@ registerAnimator('twitter-header', class {
 
 Example 3: Parallax backgrounds. {#example-3}
 -----------------------------------------
+<!-- Big Text: TODO -->
 
 TODO

--- a/index.bs
+++ b/index.bs
@@ -145,13 +145,12 @@ animations. The worklet can be accessed via {{animationWorklet}} attribute.
 
 The {{animationWorklet}}'s <a>worklet global scope type</a> is {{AnimationWorkletGlobalScope}}.
 
-<pre class='idl'>
-interface AnimationWorklet {
-  [NewObject] Promise&lt;void> addModule(USVString moduleURL);
-};
+The {{AnimationWorkletGlobalScope}} represents the <dfn>global execution context</dfn> of
+{{animationWorklet}}.
 
+<pre class='idl'>
 partial interface Window {
-    [SameObject] readonly attribute AnimationWorklet animationWorklet;
+    [SameObject] readonly attribute Worklet animationWorklet;
 };
 </pre>
 
@@ -169,18 +168,9 @@ interface AnimationWorkletGlobalScope : WorkletGlobalScope {
     Note: This is how the class should look.
     <pre class='lang-javascript'>
         class FooAnimator {
-            static get elements() {
-                return [
-                    {name: 'foo', inputProperties: ['--foo'], outputProperties: []},
-                    {name: 'bar', inputProperties: [], outputProperties: ['transform']},
-                ];
-            };
-
-            static timelines = [
-                'document',
-                { type: 'scroll', { orientation: 'vertical' } },
-            ];
-
+            constructor(options) {
+                // Called one
+            }
             animate(elementMap, timelines) {
                 // Animation frame logic goes here
             }
@@ -192,31 +182,21 @@ interface AnimationWorkletGlobalScope : WorkletGlobalScope {
 
 Concepts {#concepts}
 ====================
-A <dfn>animator definition</dfn> describes an author defined animation which can be referenced by
-an <a>animator instance</a>. It consists of:
+An <dfn>animator definition</dfn> is a <a>struct</a> which describes the author defined custom
+animation as needed by {{AnimationWorkletGlobalScope}}. It consists of:
 
  - A <dfn>class constructor</dfn>.
 
  - An <dfn>animate function</dfn>.
 
- - An <dfn>animator slot list</dfn> containing a dictionary providing each <dfn>slot name</dfn>,
-    its <dfn>input property list</dfn>, and its <dfn>output property list</dfn>.
+ - An <dfn>animator output effect</dfn>.
 
- - An <dfn>animator timeline options list</dfn>.
-
-
-Each entry in the <a>animator slot list</a> consists of:
-
- - An <dfn>animator slot</dfn> <<ident>>#.
-
- - An <dfn>animator input property list</dfn>.
-
- - An <dfn>animator output property list</dfn>.
+ - An <dfn>animator timelines list</dfn>.
 
 
-An <dfn>animator instance</dfn> describes a fully realized custom animation instance in the worklet
-context and links an <a>animator definition</a> with the instance specific state such as its element
-proxies. It consists of:
+An <dfn>animator instance</dfn> describes a fully realized custom animation instance in the
+{{AnimationWorkletGlobalScope}}. It links an <a>animator definition</a> with the instance specific state
+such as its element proxies. It consists of:
 
  - An <dfn>animator name</dfn> <<ident>>#.
 
@@ -242,6 +222,9 @@ Registering an Animator Definition {#registering-animator-definition}
 ============================================================
 The {{AnimationWorkletGlobalScope}} has a <dfn>animator name to animator definition map</dfn>.
 The map gets populated when {{registerAnimator(name, animatorCtor)}} is called.
+
+
+<div algorithm>
 
 When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
 |animatorCtor|)</dfn> method is called, the user agent <em>must</em> run the following steps:
@@ -286,7 +269,10 @@ When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
 
     11. Add the key-value pair (|name| - |definition|) to the <a>animator name to animator
         definition map</a> of the associated <a>document</a>.
+</div>
 
+
+<div algorithm>
 
 When <dfn>parsing an animator slot list</dfn> for {{animatorCtor}}, the user agent <em>must</em>
 run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -13,7 +13,7 @@ Editor: Stephen McGruer, smcgruer@chromium.org
 </pre>
 
 <pre class="link-defaults">
-spec:css-break-3; type:dfn; text:fragment
+spec:infra; type:dfn; text:list
 </pre>
 
 <pre class="anchors">
@@ -31,9 +31,12 @@ urlPrefix: https://www.w3.org/TR/css3-transitions/#; type: dfn;
     text: animatable properties
 urlPrefix: https://w3c.github.io/web-animations/#; type: dfn;
     url: the-documents-default-timeline; text: default document timeline
+    url: concept-animation; text: animation
     text: effect value
     text: effect stack
     text: target property
+    text: timeline
+    text: animation effect
 urlPrefix: https://tc39.github.io/ecma262/#sec-; type: dfn;
     text: constructor
     text: Construct
@@ -169,10 +172,10 @@ interface AnimationWorkletGlobalScope : WorkletGlobalScope {
     <pre class='lang-javascript'>
         class FooAnimator {
             constructor(options) {
-                // Called one
+                // Called when a new animator is instantiated.
             }
             animate(elementMap, timelines) {
-                // Animation frame logic goes here
+                // Animation frame logic goes here.
             }
         }
     </pre>
@@ -185,38 +188,40 @@ Concepts {#concepts}
 An <dfn>animator definition</dfn> is a <a>struct</a> which describes the author defined custom
 animation as needed by {{AnimationWorkletGlobalScope}}. It consists of:
 
+ - An <dfn>animator name</dfn> <<ident>>#.
+
  - A <dfn>class constructor</dfn>.
 
  - An <dfn>animate function</dfn>.
+
+
+
+An <dfn>animator instance</dfn> a <a>struct</a> which describes a fully realized custom animation
+instance in the {{AnimationWorkletGlobalScope}}. It has a reference to an <a>animator
+definition</a> and owns the instance specific state such as animation effects and timelines. It
+consists of:
+
+ - An <a>animator name</a>.
+
+ - An <a>animation requested flag</a>.
 
  - An <dfn>animator output effect</dfn>.
 
  - An <dfn>animator timelines list</dfn>.
 
 
-An <dfn>animator instance</dfn> describes a fully realized custom animation instance in the
-{{AnimationWorkletGlobalScope}}. It links an <a>animator definition</a> with the instance specific state
-such as its element proxies. It consists of:
+An <dfn>worklet animation</dfn> is a <a>animation</a> in the <a>document</a> which may corresponds
+to an <a>animator instance</a> in the <a>worklet global scope</a>. It provides playback control
+and controls the lifetime of its corresponding <a>animator instance</a>. It
+consists of:
 
- - An <dfn>animator name</dfn> <<ident>>#.
+ - An <a>animator name</a>.
 
- - An <a>animation requested flag</a>.
+ - An <dfn>effect</dfn> which is an <a>animation effect</a>.
 
- - A <dfn>root element</dfn>.
-
- - An <dfn>element proxy map</dfn> mapping <a>animator slot</a> to a list of <a>element proxies</a>.
+ - A <dfn>timeline</dfn> which is a <a>timeline</a>.
 
 
-An <dfn>element proxy</dfn> defines a handle to an element which can be used to read or
-write its explicitly exposed animatable attributes. It consists of:
-
- - An <a>animator instance</a>.
-
- - A <dfn>proxied element</dfn>.
-
- - A read only map of proxied input properties to their values.
-
- - A map of proxied output properties to their values.
 
 Registering an Animator Definition {#registering-animator-definition}
 ============================================================
@@ -224,7 +229,7 @@ The {{AnimationWorkletGlobalScope}} has a <dfn>animator name to animator definit
 The map gets populated when {{registerAnimator(name, animatorCtor)}} is called.
 
 
-<div algorithm>
+<div algorithm="register-animator">
 
 When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
 |animatorCtor|)</dfn> method is called, the user agent <em>must</em> run the following steps:
@@ -248,12 +253,6 @@ When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
     7. If the result of <a>IsCallable</a>(|animate|) is false, <a>throw</a> a <a>TypeError</a> and
         abort all these steps.
 
-    8. Let |elements| be the result of <a>parsing an animator slot list</a> for |animatorCtor|.
-        If an exception is thrown, rethrow the exception and abort all these steps.
-
-    9. Let |timelineOptions| be the result of <a>parsing an animator timeline options list</a> for
-        |animatorCtor|. If an exception is thrown, rethrow the exception and abort all these steps.
-
     10. Let |definition| be a new <a>animator definition</a> with:
 
         - <a>animator name</a> being |name|
@@ -262,96 +261,31 @@ When the <dfn method for=AnimationWorkletGlobalScope>registerAnimator(|name|,
 
         - <a>animate function</a> being |animate|
 
-        - <a>element proxy map</a> being |elements|
-
-        - <a>animator timeline options list</a> being |timelineOptions|
-
-
     11. Add the key-value pair (|name| - |definition|) to the <a>animator name to animator
         definition map</a> of the associated <a>document</a>.
 </div>
 
 
-<div algorithm>
+Animator Instance {#animator-instance}
+======================================
 
-When <dfn>parsing an animator slot list</dfn> for {{animatorCtor}}, the user agent <em>must</em>
-run the following steps:
+Creating an Animator Instance {#creating-animator-instance}
+-----------------------------------------------------------
 
-    1. Let |elements| be an empty <code>sequence&lt;Dictionary></code>.
-
-    1. Let |elementsIterable| be the result of <a>Get</a>(|animatorCtor|, |elements|).
-
-    2. If |elementsIterable| is not <em>undefined</em>, then for each |slot| in |elementsIterable| run the
-        following steps:
-
-        - Let |slotDictionary| be an empty dictionary.
-
-        - Let the |name| key of |slotDictionary| be the |name| value of |element|.
-
-        - Let the |inputProperties| key of |slotDictionary| be the result of
-            <a>parsing an animator property list</a> with name <em>inputProperties</em> for |slot|.
-
-        - Let the |outputProperties| key of |slotDictionary| be the result of
-            <a>parsing an animator property list</a> with name <em>outputProperties</em> for |slot|.
-
-        - Push |slotDictionary| onto |elements|.
-
-
-When <dfn>parsing an animator property list</dfn> with name <em>name</em> for <em>slot</em>,
-the user agent <em>must</em> run the following steps:
-
-    1. Let |properties| be an empty <code>sequence&lt;DOMString></code>.
-
-    2. Let |propertiesIterable| be the result of <a>Get</a>(|slot|, |name|).
-
-    3. If |propertiesIterable| is not <em>undefined</em>, then set |properties| to the result of
-        converting |propertiesIterable| to a <code>sequence&lt;DOMString></code>. If an
-        exception is thrown, rethrow the exception and abort all these steps.
-
-When <dfn>parsing an animator timeline options list</dfn> for {{animatorCtor}},
-the user agent <em>must</em> run the following steps:
-
-    1. Let |timelineOptions| be an empty <code>sequence&lt;Object></code>.
-
-    2. Let |timelinesIterable| be the result of <a>Get</a>(|animatorCtor|, |timelines|).
-
-    3. For each |timeline| in |timelinesIterable|, run the following steps:
-
-        1. If <a>Type</a>(|timeline|) is {{DOMString}} let |timelineObject| be <code>{ type:
-             |timeline|, options: {} }</code>, otherwise let |timelineObject| be |timeline|.
-
-        2. Let |type| be the result of <a>Get</a>(|timelineObject|, "type").
-
-        3. Let |options| be the result of <a>Get</a>(|timelineObject|, "options").
-
-        4. Process |type| and |options| according to the first matching condition in the following:
-
-             <div class="switch">
-
-             :  If |type| or |options| is <b>undefined</b>,
-             :: throw a <a>NotSupportedError</a> and abort all remaining steps.
-
-             :  If |type| is "document",
-             :: Push a {{DocumentTimelineOptions}} created from |options| onto |timelineOptions|.
-
-             :  If |type| is "scroll",
-             :: Push a {{ScrollTimelineOptions}} created from |options| onto |timelineOptions|.
-
-             :  Otherwise,
-             :: throw a <a>NotSupportedError</a> and abort all remaining steps.
-
-             </div>
-
-Creating an Animator {#creating-animator}
-====================================================
 Each <a>animator instance</a> lives in an {{AnimationWorkletGlobalScope}}. The
 <a>animator instance</a> cannot be disposed arbitrarily (e.g., in the middle of running animation
 as it may contain the scripted animation state.
 
-The {{AnimationWorkletGlobalScope}} has an <dfn>(animator name, root element) to instance map</dfn>.
-The map is populated when the user agent constructs a new <a>animator instance</a> in that scope.
+Issue: This is no longer true as we provide destroy callback.
 
-To <dfn>create a new animator instance</dfn> given a |name|, |root element|, and |workletGlobalScope|,
+The {{AnimationWorkletGlobalScope}} has an <dfn>animation id to instance map</dfn>.
+The map is populated when the user agent constructs a new <a>animator instance</a> in that scope
+that corresponds to a worklet animation in the document scope.
+
+<div algorithm="create-animator">
+
+To <dfn>create a new animator instance</dfn> given a |name|, |animationId|,
+|timeline|, |effect|, and |workletGlobalScope|,
 the user agent <em>must</em> run the following steps:
 
     1. Let the |definition| be the result of looking up |name| on the |workletGlobalScope|'s
@@ -359,314 +293,145 @@ the user agent <em>must</em> run the following steps:
 
           If |definition| does not exist abort the following steps.
 
-    2. Let |animatorInstanceMap| be |workletGlobalScope|'s <a>(animator name, root element) to
+    2. Let |animatorInstanceMap| be |workletGlobalScope|'s <a>animation id to
          instance map</a>.
 
-    3. If an entry exists for |name| and |root element| within |animatorInstanceMap| then abort the
+    3. If an entry exists for |animationId| within |animatorInstanceMap| then abort the
          following steps.
 
     4. Let |animatorCtor| be the <a>class constructor</a> of |definition|.
 
-    5. Let |animatorInstance| be the result of <a>Construct</a>(|animatorCtor|).
+    5. Let |timelineList| be a new <a>list</a> with |timeline| added to it.
 
-        If <a>Construct</a> throws an exception, set the result of looking up |name| and
-        |root element| in |animatorInstanceMap| to <b>null</b>, and abort the following steps.
+    6. Let |animatorInstance| be the result of <a>Construct</a>(|animatorCtor|).
+
+        If <a>Construct</a> throws an exception, set the result of looking up |animationId| in
+        |animatorInstanceMap| in |animatorInstanceMap| to <b>null</b>, and abort the following
+        steps.
 
     6. Set the following on |animatorInstance| with:
         - <a>animator name</a> being |name|
         - <a>animation requested flag</a> being <a>frame-current</a>
+        - <a>animator output effect</a> being |effect|
+        - <a>animator timelines list</a> being |timelineList|
 
-    7. Set the result of looking up |name| and |root element| in |animatorInstanceMap| to
+    7. Set the result of looking up |animationId| in |animatorInstanceMap| to
          |animatorInstance|.
 
+</div>
 
-Creating an Element Proxy {#creating-element-proxy}
-====================================================
-<a>Element Proxy</a> objects are created by the user agent for elements which have either 'animator'
-or 'animator-root' CSS properties. They cannot be constructed from user script. A single element may
-have multiple <a>Element Proxy</a> objects associated with it; one per <a>animator instance</a>.
-
-The {{ElementProxy}} interface exposes two maps: a read only map of proxied input properties to their
-values, and a map of proxied output properties to their values. The input and output properties in
-the maps are those specified in registerAnimator for the given <a>animator instance</a>.
-
-<pre class='idl'>
-[
-    Exposed=(AnimationWorklet),
-] interface ElementProxy {
-    attribute StylePropertyMapReadOnly inputStyleMap;
-    attribute StylePropertyMapReadOnly outputStyleMap;
-};
-</pre>
-
-Issue: Todo: Should we have NoInterfaceObject/Exposed here? How do we properly represent that this
-cannot be constructed via javascript?
-
-When user agent wants to <dfn>create an element proxy</dfn> given |element| with a given |animatorSlot|, it
-<em>must</em> run the following steps:
-
-    1. Let |animatorInstance| be the <a>animator instance</a> associated with |element|
-
-    2. Let |workletGlobalScope| be the scope associated with |animatorInstance|.
-
-    3. Let |definition| be the result of looking up |name| on the |workletGlobalScope|'s
-        <a>animator name to animator definition map</a>.
-
-    4. Let |slot| be the result of finding the item with name |animatorSlot| in the
-        <a>animator slot list</a> of |definition|.
-
-    5. Let |inputProperties| be <a>animator input property list</a> of |slot|.
-
-    6. Let |outputProperties| be <a>animator output property list</a> of |slot|.
-
-    6. Let |proxy| be a new {{ElementProxy}} Object with:
-
-        - <a>proxied element</a> being |element|.
-
-        - {{outputStyleMap}} being a new {{StylePropertyMap}} for |outputProperties|.
-
-    7. <a>update proxy input style map</a> with |proxy| and |inputProperties|.
-
-    8. Associate |proxy| with  |animatorInstance|.
-
-    9. Return proxy.
-
-
-Note: Writing to the outputStyle map will update the effective value of the used style value of the
-<a>proxied element</a>. This <em>may</em> happen asynchronously.
-
-
-When the user agent wants to <dfn>update proxy input style map</dfn> given |proxy|, and
-|properties|, it <em>must</em> run the following steps:
-
-
-    1. Let |styleMap| be a new {{StylePropertyMapReadOnly}} populated with <em>only</em> the
-        <a>computed value</a> of <a>proxied element</a> for properties listed in |properties|.
-
-    2. Set |proxy|'s inputStyleMap to |styleMap|.
-
-
-When an element is removed, all proxies of that element are considered to be disconnected.
-A disconnected proxy continues to have the last value from the <a>computed value</a>
-of the <a>proxied element</a> properties, but setting values on its outputStyleMap will have no
-effect.
-
-
-Requesting Animation Frames {#requesting-animation-frames}
-====================
-Each <a>animator instance</a> has an associated <dfn>animation requested flag</dfn>. It must be
-either <dfn>frame-requested</dfn> or <dfn>frame-current</dfn>. It is initially set to
-<a>frame-current</a>. Various events can cause the <a>animation requested flag</a> to be set to
-<a>frame-requested</a>.
-
-[[#running-animators]] resets the <a>animation requested flag</a> on animators to
-<a>frame-current</a>.
-
-Element proxy creation/removal {#requesting-animation-frames-element-proxy}
-------------------------------
-
-When a new element proxy is assigned to or removed from an <a>animator instance</a>, that
-<a>animator instance</a>'s <a>animation requested flag</a> should be set to <a>frame-requested</a>.
-
-Change in an element's computed style {#requesting-animation-frames-computed-style}
--------------------------------------
-
-When the computed style for an element changes, the user agent <em>must</em> run the following steps:
-
-For each <a>element proxy</a> for that element, perform the following steps:
-
-    1. Let |proxy| be the current <a>element proxy</a> of the element.
-
-    2. Let |animator| be the |proxy|'s assigned animator.
-
-    3. Let |name| be the |animator|'s name.
-
-    4. Let |definition| be the result of looking up |name| on the |workletGlobalScope|'s
-        <a>animator name to animator definition map</a>.
-
-    5. Let |slot| be the result of finding the item with name |animatorSlot| in the
-        <a>animator slot list</a> of |definition|.
-
-    6. Let |inputProperties| be <a>animator input property list</a> of |slot|.
-
-    7. For each property in |inputProperties|, if the property’s computed value has changed,
-        set the <a>animation requested flag</a> on the |animator| to <a>frame-requested</a>.
-
-Animator specifies a DocumentTimeline {#requesting-animation-frames-document-timeline}
--------------------------------------
-
-If a {{DocumentTimelineOptions}} instance is present in an animator's <a>animator timeline options
-list</a> then that animator's <a>animation requested flag</a> <em>must</em> be set to
-<a>frame-requested</a> at the start of each animation frame.
-
-Animator specifies a ScrollTimeline {#requesting-animation-frames-scroll-timeline}
------------------------------------
-
-If a {{ScrollTimelineOptions}} |instance| is present in an animator's <a>animator timeline options
-list</a> then the user agent <em>must</em> run the following steps when the scroll position of the
-nearest non-visible overflow ancestor to the animator’s <a>root element</a> changes:
-
-  1. For each {{ScrollTimelineOptions}} instance |options| in the animator's <a>animator timeline
-       options list</a> do the following steps:
-
-    1. Let |timeline| be a {{ScrollTimeline}} created from |options|, adding the nearest non-visible
-         overflow ancestor of the <a>root element</a> as the {{scrollSource}}.
-
-    2. If the <a>current time of the ScrollTimeline</a> |timeline| would have changed due to the
-         change in scroll position, set the animator's <a>animation requested flag</a> to
-         <a>frame-requested</a>.
-
-Issue: Give each animator instance a re-used set of AnimationTimelines instead of creating them
-       specifically here and when running animations.
-
-Issue: Need to add a definition for 'nearest non-visible overflow ancestor' to make sure all mentions
-       stay in sync.
 
 Running Animators {#running-animators}
-======================================================
+--------------------------------------
 
 When a user agent wants to produce a new animation frame, if for any <a>animator instance</a> the
 associated <a>animation requested flag</a> is <a>frame-requested</a> then the the user agent
 <em>must</em> <a>run animators</a> for the current frame.
 
-Note: The user agent is not required to run animations on every frame. It is legal to defer
+Note: The user agent is not required to run animations on every visual frame. It is legal to defer
       generating an animation frame until a later frame. This allow the user agent to
       provide a different service level according to their policy.
 
 
-When the user agent wants to <dfn>run animators</dfn> in a given |workletGlobalScope|, it
-<em>must</em> iterate over all pairs of animator name and root element as (|animatorName|,
-|rootElement|). For each such pair:
+<div algorithm="run-animators">
 
-  1. Let the |definition| be the result of looking up |animatorName| on the |workletGlobalScope|'s
+When the user agent wants to <dfn>run animators</dfn> in a given |workletGlobalScope|, it
+<em>must</em> iterate over all animation id as |animationId|. For each item:
+
+  1. Let |instance| be the result of looking up |animationId| in the
+        |workletGlobalScope|'s <a>animation id to instance map</a>.
+
+      If |instance| does not exist then abort the following steps.
+
+  2. Let |animatorName| be |instance|'s <a>animator name</a>
+
+  3. Let the |definition| be the result of looking up |animatorName| on the |workletGlobalScope|'s
         <a>animator name to animator definition map</a>.
 
       If |definition| does not exist then abort the following steps.
 
-  2. Let |instance| be the result of looking up (|animatorName|, |rootElement|) in the
-        |workletGlobalScope|'s <a>(animator name, root element) to instance map</a>.
+  4. If the <a>animation requested flag</a> for |instance| is <a>frame-current</a> or the effect
+       belonging to the |instance| will not be visible within the visual viewport of the current
+       frame the user agent <em>may</em> abort all the following steps.
 
-      If |instance| does not exist then <a>create a new animator instance</a> for |animatorName|,
-      |rootElement|, and |workletGlobalScope|, and let |instance| be the result of that.
-
-  3. If |instance| still does not exist or |instance| is <b>null</b> then abort the following steps.
-
-  4. If the <a>animation requested flag</a> for |instance| is <a>frame-current</a> or the proxies
-        belonging to |instance| will not be visible within the visual viewport of the current frame
-        the user agent <em>may</em> abort all the following steps.
-
-        Issue: Consider giving user agents permission to skip running animator instances to throttle
-        slow animators.
+        Issue: Consider giving user agents permission to skip running animator instances to
+        throttle slow animators.
 
   5. Let |animateFunction| be |definition|'s <a>animate function</a>.
 
-  6. Let |timelines| be an empty <code>sequence&lt;AnimationTimeline></code>.
+  6. Let |timelines| be </a>animator timelines list</a> of |instance|.
 
-  7. For each |timelineOptions| in the <a>animator timeline options list</a> of |definition|, do the
-       following:
+  8. Let |effect| be an <a>animator</a> of |instance|.
 
-    - If <a>Type</a>(|timelineOptions|) is {{DocumentTimelineOptions}}, push a new
-        {{DocumentTimeline}} created using |timelineOptions| to the |timelines| list.
-
-    - If <a>Type</a>(|timelineOptions|) is {{ScrollTimelineOptions}}, push a new {{ScrollTimeline}}
-        created using |timelineOptions| to the |timelines| list, adding the nearest non-visible
-        overflow ancestor of |rootElement| as the {{scrollSource}}.
-
-  8. Let |elementMap| be an <a>element proxy map</a> of |instance|.
-
-  9. <a>Invoke</a> |animateFunction| with arguments «|elementMap|, |timelines|»,
+  9. <a>Invoke</a> |animateFunction| with arguments «|timelines|, |effect|»,
         and with |instance| as the <a>callback this value</a>.
 
+</div>
 Note: Although inefficient, it is legal for the user agent to <a>run animators</a> multiple times
 in the same frame.
 
-Closing an Animator {#closing-animator}
-====================================================
+Removing an Animator {#removing-animator}
+-----------------------------------------
 
-Issue: Todo: Define when we may get rid of the animator.
+Issue: Define when we may get rid of the animator.
+
+Requesting Animation Frames {#requesting-animation-frames}
+----------------------------------------------------------
+
+Each <a>animator instance</a> has an associated <dfn>animation requested flag</dfn>. It must be
+either <dfn>frame-requested</dfn> or <dfn>frame-current</dfn>. It is initially set to <a>frame-
+current</a>. Various events, for example changes in of the animator's <a>animator timelines
+list</a>  currentTime can cause the <a>animation requested flag</a> to be set to <a>frame-
+requested</a>.
+
+[[#running-animators]] resets the <a>animation requested flag</a> on animators to
+<a>frame-current</a>.
 
 
-CSS Animator Notation {#css-animator-notation}
-==============================================
+Integration With Web Animations {#integration-web-animation}
+===============================
 
-Two CSS properties 'animator-root' and 'animator' may be used to assign an HTML elements to an
-<a>animator instance</a> either as a root element or a child element.
+Creating an Worklet Animation {#creating-worklet-animation}
+-----------------------------------------------------------
+TODO:
+  - add IDL for worklet animation
+  - describe how constructor handles single or sequence of effects
+  - define new semantics for reverse/finish/playbackRate.
+  - define what happens when timeline or effect is modified document scope
+  - define what it means when localTime is read on this instance (i.e., we get last value synced
+    from worklet scope)
 
-<pre class='propdef'>
-Name: animator-root
-Value:  none | [<a>animator name</a> <a>animator slot</a>, ]* <a>animator name</a> <a>animator slot</a>
-Initial: none
-Applies to: all elements
-Inherited: no
-Computed value: as specified
-Percentages: N/A
-Media: interactive
-Animatable: no
-</pre>
+Issue(62): describe how constructor handles single or sequence of effects
+Issue(63): define new semantics for reverse/finish/playbackRate
 
-<dl dfn-type=value dfn-for=animator-root>
-    <dt><dfn>none</dfn>
-    <dd>
-      There will be no <a>animator instance</a> that has this element as its
-      <a>root element</a>.
-    <dt><a>animator name</a> <a>animator slot</a>
-    <dd>
-      For each <a>animator name</a> specified in the list, the following applies for each animation frame:
+Timeline Attachment {#timeline-attachment}
+-------------------
 
-      * If there is no <a>animator definition</a> registered with the given <a>animator name</a>, the inclusion
-        of that <a>animator name</a> as a value has no effect.
+TODO
 
-      * Otherwise, an <a>animator instance</a> with this element as its <a>root element</a>
-        will exist and will have its <a>animate function</a> called (with respect to the rules
-        laid out in [[#running-animators]]) with an <a>element proxy</a> for this element passed as
-        one of the <a>element proxies</a> for the given <a>animator slot</a>.
+Issue(61): Define semantics of attachment and detachment
 
-      If the same <a>animator name</a> occurs multiple times in the list, only the first occurrence of that
-      <a>animator name</a> is processed.
-</dl>
+WorkletGroupEffect {#worklet-group-effect}
+------------------
+TODO:
+  - Add idl for worklet group effect
+  - define the children start time schedule for the group effect. [Issue](https://github.com/w3c/web-animations/issues/191)
 
-<pre class='propdef'>
-Name: animator
-Value:  none | [<a>animator name</a> <a>animator slot</a>, ]* <a>animator name</a> <a>animator slot</a>
-Initial: none
-Applies to: all elements
-Inherited: no
-Computed value: as specified
-Percentages: N/A
-Media: interactive
-Animatable: no
-</pre>
-
-<dl dfn-type=value dfn-for=animator>
-    <dt><dfn>none</dfn>
-    <dd>
-      This element will not be passed into any <a>animate function</a> as one of the
-      <a>element proxies</a>.
-    <dt><a>animator name</a> <a>animator slot</a>
-    <dd>
-      For each <a>animator name</a> specified in the list, the following applies for each animation frame:
-
-      * If there is no <a>animator definition</a> registered with the given <a>animator name</a>, the inclusion
-        of that <a>animator name</a> as a value has no effect.
-
-      * Otherwise, an <a>element proxy</a> for this element will be passed into the
-        <a>animate function</a> of the closest ancestor <a>animator instance</a> with the given
-        <a>animator name</a> as one of the <a>element proxies</a> for the given <a>animator slot</a>. If no
-        such <a>animator instance</a> exists, one is created with the document root element as its
-        <a>root element</a>.
-
-      If the same <a>animator name</a> occurs multiple times in the list, only the first occurrence of that
-      <a>animator name</a> is processed.
-</dl>
+WorkletAnimation timing model {#timing-model}
+------------------------------------
+TODO:
+ - Describe the relation of WorkletAnimation.currentTime with its timeline time
+ - Describe the relation of WorkletAnimation.effect.getComputedTiming().localTime with the local time
+    set in the worklet scope.
 
 
 Effect Stack {#effect-stack}
-============================
+----------------------------
 
-Issue: Todo: the animators output style values have the highest order in animation stack effect and
-their composite operation is "replace" which is going to allow them to run independent on other
-animations and in a different thread. Supporting other composite operation is not in scope at this
-point.
+Issue: Worklet animations will have a special animation class that  ranks them with the highest
+order in animation stack effect. also their composite operation is "replace" which is going to
+allow them to run in parallel to other web animations in the system. Supporting other
+composite operation is not in scope at this point.
 
 
 Security Considerations {#security-considerations}
@@ -682,127 +447,120 @@ Issue: Need to decide what privacy considerations there are for this spec.
 Examples {#examples}
 ====================
 
-Example 1: A fade-in animation with spring timing. {#example-1}
+Example 1: Hidey Bar. {#example-1}
 -----------------------------------------
+An example of header effect where a header is moved with scroll and as soon as finger is lifted it animates fully to close or open position depending on its current position.
 
 <pre class='lang-markup'>
-&lt;style&gt;
-.myFadein {
-  animator: 'spring' 'fadein';
-}
-&lt;/style&gt;
-
-
-&lt;section class='myFadein'&gt;&lt;/section&gt;
-&lt;section class='myFadein' style="--spring-k: 25;"&gt;&lt;/section&gt;
+&lt;div id='scrollingContainer'&gt;
+  &lt;div id='header'&gt;Some header&lt;/div&gt;
+  &lt;div&gt;content&lt;/div&gt;
+&lt;/div&gt;
 
 &lt;script&gt;
-document.animationWorklet.import('spring-timing.js');
-&lt;/script&gt;
+animationWorklet.addModule('hidey-bar-animator.js').then( _ =&gt; {
+  const scrollTimeline = new ScrollTimeline($scrollingContainer, {timeRange: 100});
 
+  var workletAnim = new WorkletAnimation('hidey-bar',
+    new KeyFrameEffect($header,
+                       [{transform: 'translateX(100px)'}, {transform: 'translateX(0px)'}],
+                       {duration: 100, iterations: 1, fill: 'both' })
+    [scrollTimeline, document.timeline],
+  );
+});
+
+
+workletAnim.timeline == scrollTimeline; // true, timeline returns the primary timeline
+
+&lt;/script&gt;
 </pre>
 
 <pre class='lang-javascript'>
 // Inside AnimationWorkletGlobalScope
-registerAnimator('spring', class {
 
-    static elements = [
-        {name: 'fadein', inputProperties:  ['--spring-k'], outputProperties =  ['opacity']}];
-    static timelines = ['document'];
+registerAnimator('hidey-bar', class {
+  animate(timelines, effects) {
+    const scroll = timeline[0].currentTime;  // [0, 100]
+    const time = timelines[1].currentTime;
 
-    animate(elementMap, timelines) {
-        this.startTime_ = this.startTime_ || timelines[0].currentTime;
-        const deltaT = timelines[0].currentTime - this.startTime_;
-        elementMap.get('fadein').forEach(elem => {
-          // read a custom css property.
-          const k = elem.inputStyleMap.get('--spring-k') || 1;
-          // compute progress using a fancy spring timing function.
-          const effectiveValue = 1 * springTiming(deltaT, k);
-          // update opacity accordingly.
-          elem.ouputStyleMap.opacity = effectiveValue;
-        });
+    activelyScrolling = timeline[0].phase == 'active';
+
+    let localTime;
+    if (activelyScrolling) {
+      this.startTime_ = undefined;
+      localTime = scroll;
+    } else {
+      this.startTime_ = this.startTime_ || time;
+      // Decide on close/open direction depending on how far we have scrolled the header
+      // This can even do more sophisticated animation curve by computing the scroll velocity and
+      // using it.
+      this.direction_ = scroll >= 50 ? +1 : -1;
+      localTime = this.direction_ * (time - this.startTime_);
     }
 
-    springTiming(deltaT, k) {
-        // simulate the spring effect and return a progress value between [-1, 1];
-    }
+    // Drive the output effects by setting its local time.
+    effect.localTime = localTime;
+  }
 });
+
 </pre>
+
+Issue: This example uses a hypothetical 'phase' property on timeline as a way to detect when user
+is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
+fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
+the last few frames.
 
 
 Example 2: Twitter header. {#example-2}
 --------------------------
+An example of twitter profile header effect where two elements (avatar, and header) are updated in
+sync with scroll offset.
 
 
 <pre class='lang-markup'>
-&lt;style&gt;
-#scroller {
-  animator-root: twitter-header;
-}
-.avatar {
-  animator: twitter-header avatar;
-}
-.bar {
-  animator: twitter-header bar;
-}
-&lt;/style&gt;
-
-&lt;div id="scroller"&gt;
-  &lt;section class="bar"&gt;&lt;/section&gt;
-  &lt;header&gt;
-    &lt;picture class="avatar"&gt;
-      &lt;img src="avatar.jpg"&gt;
-    &lt;/picture&gt;
-    &lt;section&gt;
-      &lt;button&gt;Friends&lt;/button&gt;
-      &lt;button&gt;Edit Profile&lt;/button&gt;
-    &lt;/section&gt;
-  &lt;/header&gt;
+// In document scope
+&lt;div id='scrollingContainer'&gt;
+  &lt;div id='header' style='height: 150px'&gt;&lt;/div&gt;
+  &lt;div id='avatar'&gt;&lt;img&gt;&lt;/div&gt;
 &lt;/div&gt;
 
 &lt;script&gt;
-document.animationWorklet.import('tweeter-header.js');
+animationWorklet.addModule('twitter-header-animator.js').then( _ =&gt; {
+  const workletAnim = new WorkletAnimation('twitter-header',
+    [new KeyFrameEffect($avatar,  /* scales down as we scroll up */
+                        [{transform: 'scale(1)'}, {transform: 'scale(0.5)'}],
+                        {duration: 1, iterations: 1}),
+     new KeyFrameEffect($header, /* loses transparency as we scroll up */
+                        {opacity: 0, opacity: 0.8},
+                        {duration: 1, iterations: 1})] ,
+     [new ScrollTimeline($scrollingContainer, {timeRange: 1, startScrollOffset: 0, endScrollOffset: $header.clientHeight})],
+  );
+
+  // Same animation instance is accessible via different animation targets
+  workletAnim == $avatarEl.getAnimations()[0] == $headerEl.getAnimations()[0];
+
+});
 &lt;/script&gt;
 
 </pre>
 
 <pre class='lang-javascript'>
-// Inside AnimationWorkletGlobalScope.
+// Ins AnimationWorkletGlobalScope.
 registerAnimator('twitter-header', class {
-
-  static elements =  [
-    {name: 'avatar', inputProperties: [], outputProperties: ['transform']},
-    {name: 'bar', inputProperties: [], outputProperties: ['opacity']}
-  ];
-
-  // maps scroll offset [0, 140px] -> time values [0, 1]
-  static timelines = [ { type: 'scroll', options: {
-      orientation: 'vertical',
-      endScrollOffset: '140px',
-      timeRange: 1
-    }},
-  ];
-
-
-  animate(elementMap, timelines) {
-    var progress = timelines[0].currentTime;
-
-    elementMap.get('avatar').forEach(elem => {
-      elem.outputStyleMap.set('transform', new CSSTransformValue([
-          new CSSTranslation(new CSSSimpleLength(0, 'px'),
-                             new CSSSimpleLength(tween(140, 45)(progress), 'px')),
-          new CSSScale(tween(1, 0.5)(progress), tween(1, 0.5)(progress))
-          ]));
-    });
-    elementMap.get('bar').forEach(elem => {
-      elem.outputStyleMap.set('opacity', progress);
-    });
+  constructor(options) {
+    this.timing_ = new CubicBezier('ease-out');
   }
 
-  tween(begin, end) {
-    return function lerp(progress) {
-        return begin + (end - begin) * progress;
-    }
+  clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  animate(timelines, effect) {
+    const scroll = timeline[0].currentTime;  // scroll is in [0, 1] range
+
+    // Drive the output group effect by setting its children local times individually.
+    effects.children[0].localTime = scroll;
+    effects.children[1].localTime = this.timing_(clamp(scroll, 0, 0.5));
   }
 });
 
@@ -811,57 +569,4 @@ registerAnimator('twitter-header', class {
 Example 3: Parallax backgrounds. {#example-3}
 -----------------------------------------
 
-<pre class='lang-markup'>
-&lt;style&gt;
-#scroller {
-  animator-root: 'parallax';
-}
-.background {
-  animator: 'parallax' 'background';
-}
-
-&lt;/style&gt;
-
-&lt;div id="scroller"&gt;
-    &lt;div class="background" style="--parallax-rate: 0.6" &gt;
-    &lt;/div&gt;
-    &lt;div class="background" style="--parallax-rate: 0.3" &gt;
-    &lt;/div&gt;
-
-    overflowing content!
-&lt;/div&gt;
-
-&lt;script&gt;
-document.animationWorklet.import('parallax.js');
-&lt;/script&gt;
-
-
-</pre>
-
-<pre class='lang-javascript'>
-// Inside AnimationWorkletGlobalScope
-registerAnimation('parallax', class {
-
-    static elements =  [
-        { name: 'background', inputProperties: ['--parallax-rate'], outputProperties: ['transform']}
-    ];
-
-    static timelines = [{ type: 'scroll', options: { orientation: 'vertical'} }];
-
-    // This can be passed in as an input but we should consider exposing this in ScrollTimeline
-    static SCROLL_SIZE = 1000;
-
-    animate(elementMap, timelines) {
-        // read root scroller vertical scroll offset.
-        const scrollTop = timelines[0].currentTime * SCROLL_SIZE;
-        // update parallax transform
-        elementMap.get('background').forEach(elem => {
-           const rate = elem.inputStyleMap.get('--parallax-rate') || 0.2;
-           elem.outputStyleMap.set('transform', new CSSTransformValue([
-            new CSSTranslation(new CSSSimpleLength(0, 'px'), new CSSSimpleLength(rate * scrollTop, 'px'))]));
-        });
-    }
-});
-</pre>
-
-
+TODO

--- a/index.bs
+++ b/index.bs
@@ -55,7 +55,6 @@ urlPrefix: https://wicg.github.io/scroll-animations/#; type: interface
     url: dom-scrolltimeline-scrollsource; text: scrollSource
 urlPrefix: https://wicg.github.io/scroll-animations/#; type: dfn
     url: current-time-algorithm; text: current time of the ScrollTimeline;
-
 </pre>
 
 <pre class=biblio>

--- a/index.bs
+++ b/index.bs
@@ -55,6 +55,7 @@ urlPrefix: https://wicg.github.io/scroll-animations/#; type: interface
     url: dom-scrolltimeline-scrollsource; text: scrollSource
 urlPrefix: https://wicg.github.io/scroll-animations/#; type: dfn
     url: current-time-algorithm; text: current time of the ScrollTimeline;
+
 </pre>
 
 <pre class=biblio>
@@ -88,7 +89,6 @@ The <a>Animation Worklet</a> provides a method to create scripted animations tha
 animations to run in their own dedicated thread to provide a degree of performance isolation
 from main thread.
 
-
 <strong>Relationship to Web Animation API</strong>: Animations that are running inside a
 <a>Animation Worklet</a> execution context expose the same {{Animation}} interface on the main
 javascript execution context. So they can be created, played, canceled, inspected, and generally
@@ -96,7 +96,6 @@ controlled from main thread using Web Animation APIs. However, worklet animation
 different timing model which enables them to be script-driven, statefull, and runnable in a
 parallel worklet execution context. As such Web Animation API that seek or alter the input
 time (reverse, finish, etc.) has a different semantic for worklet animations.
-
 
 Note: <strong>Access to input</strong>: We are interested on exposing additional user input (e.g.,
 scrolling input) to these animations so that authors can create jank-free input driven animations

--- a/index.html
+++ b/index.html
@@ -1424,7 +1424,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Animation Worklet API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-19">19 July 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-20">20 July 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.html
+++ b/index.html
@@ -1579,7 +1579,7 @@ animations. The worklet can be accessed via <code class="idl"><a data-link-type=
     constructor<span class="p">(</span>options<span class="p">)</span> <span class="p">{</span>
         <span class="c1">// Called when a new animator is instantiated.</span>
 <span class="c1"></span>    <span class="p">}</span>
-    animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
+    animate<span class="p">(</span>timelines<span class="p">,</span> effect<span class="p">)</span> <span class="p">{</span>
         <span class="c1">// Animation frame logic goes here.</span>
 <span class="c1"></span>    <span class="p">}</span>
 <span class="p">}</span>

--- a/index.html
+++ b/index.html
@@ -1424,7 +1424,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Animation Worklet API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-20">20 July 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-19">19 July 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.html
+++ b/index.html
@@ -1424,12 +1424,13 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Animation Worklet API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-21">21 July 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-24">24 July 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/animation-worklet/">https://wicg.github.io/animation-worklet/</a>
      <dt>Issue Tracking:
+     <dd><a href="https://github.com/majido/animation-worklet/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:majidvp@google.com">Majid Valipour</a>
@@ -1468,7 +1469,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#concepts"><span class="secno">5</span> <span class="content">Concepts</span></a>
     <li><a href="#registering-animator-definition"><span class="secno">6</span> <span class="content">Registering an Animator Definition</span></a>
     <li>
-     <a href="#animator-instance0"><span class="secno">7</span> <span class="content">Animator Instance</span></a>
+     <a href="#animator-instance-section"><span class="secno">7</span> <span class="content">Animator Instance</span></a>
      <ol class="toc">
       <li><a href="#creating-animator-instance"><span class="secno">7.1</span> <span class="content">Creating an Animator Instance</span></a>
       <li><a href="#running-animators"><span class="secno">7.2</span> <span class="content">Running Animators</span></a>
@@ -1591,9 +1592,9 @@ animation as needed by <code class="idl"><a data-link-type="idl" href="#animatio
     <li data-md="">
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-name">animator name</dfn> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>#.</p>
     <li data-md="">
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="class-constructor">class constructor</dfn>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="class-constructor">class constructor</dfn> which is the class <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-constructor">constructor</a>.</p>
     <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animate-function">animate function</dfn>.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animate-function">animate function</dfn> which is the animate <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-function">function</a> callback.</p>
    </ul>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-instance">animator instance</dfn> a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct">struct</a> which describes a fully realized custom animation
 instance in the <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-4">AnimationWorkletGlobalScope</a></code>. It has a reference to an <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-1">animator
@@ -1605,21 +1606,20 @@ consists of:</p>
     <li data-md="">
      <p>An <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-1">animation requested flag</a>.</p>
     <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-output-effect">animator output effect</dfn>.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-effect">animator effect</dfn> which is an <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#animation-effect">animation effect</a>.</p>
     <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-timelines-list">animator timelines list</dfn>.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-timelines-list">animator timelines list</dfn> which is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> of <a data-link-type="dfn" href="#timeline" id="ref-for-timeline-1">timelines</a>.</p>
    </ul>
    <p>An <dfn data-dfn-type="dfn" data-noexport="" id="worklet-animation">worklet animation<a class="self-link" href="#worklet-animation"></a></dfn> is a <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#concept-animation">animation</a> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a> which may corresponds
-to an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-1">animator instance</a> in the <a data-link-type="dfn">worklet global scope</a>. It provides playback control
-and controls the lifetime of its corresponding <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-2">animator instance</a>. It
-consists of:</p>
+to an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-1">animator instance</a> in the worklet global scope. It controls the lifetime of its
+corresponding <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-2">animator instance</a> and provides playback control. It consists of:</p>
    <ul>
     <li data-md="">
      <p>An <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-2">animator name</a>.</p>
     <li data-md="">
      <p>An <dfn data-dfn-type="dfn" data-noexport="" id="effect">effect<a class="self-link" href="#effect"></a></dfn> which is an <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#animation-effect">animation effect</a>.</p>
     <li data-md="">
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="timeline">timeline</dfn> which is a <a data-link-type="dfn" href="#timeline" id="ref-for-timeline-1">timeline</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="timeline">timeline</dfn> which is a <a data-link-type="dfn" href="#timeline" id="ref-for-timeline-2">timeline</a>.</p>
    </ul>
    <h2 class="heading settled" data-level="6" id="registering-animator-definition"><span class="secno">6. </span><span class="content">Registering an Animator Definition</span><a class="self-link" href="#registering-animator-definition"></a></h2>
     The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-5">AnimationWorkletGlobalScope</a></code> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-name-to-animator-definition-map">animator name to animator definition map</dfn>.
@@ -1658,7 +1658,7 @@ abort all these steps.</p>
 definition map</a> of the associated <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
     </ol>
    </div>
-   <h2 class="heading settled" data-level="7" id="animator-instance0"><span class="secno">7. </span><span class="content">Animator Instance</span><a class="self-link" href="#animator-instance0"></a></h2>
+   <h2 class="heading settled" data-level="7" id="animator-instance-section"><span class="secno">7. </span><span class="content">Animator Instance</span><a class="self-link" href="#animator-instance-section"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="creating-animator-instance"><span class="secno">7.1. </span><span class="content">Creating an Animator Instance</span><a class="self-link" href="#creating-animator-instance"></a></h3>
    <p>Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-3">animator instance</a> lives in an <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-6">AnimationWorkletGlobalScope</a></code>. The <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-4">animator instance</a> cannot be disposed arbitrarily (e.g., in the middle of running animation
 as it may contain the scripted animation state.</p>
@@ -1695,7 +1695,7 @@ steps.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-2">animation requested flag</a> being <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-1">frame-current</a></p>
        <li data-md="">
-        <p><a data-link-type="dfn" href="#animator-output-effect" id="ref-for-animator-output-effect-1">animator output effect</a> being <var>effect</var></p>
+        <p><a data-link-type="dfn" href="#animator-effect" id="ref-for-animator-effect-1">animator effect</a> being <var>effect</var></p>
        <li data-md="">
         <p><a data-link-type="dfn" href="#animator-timelines-list" id="ref-for-animator-timelines-list-1">animator timelines list</a> being <var>timelineList</var></p>
       </ul>
@@ -1731,7 +1731,7 @@ associated <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-
      <li data-md="">
       <p>Let <var>timelines</var> be animator timelines list of <var>instance</var>.</p>
      <li data-md="">
-      <p>Let <var>effect</var> be an <a data-link-type="dfn">animator</a> of <var>instance</var>.</p>
+      <p>Let <var>effect</var> be an <a data-link-type="dfn" href="#animator-effect" id="ref-for-animator-effect-2">animator effect</a> of <var>instance</var>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#es-invoking-callback-functions">Invoke</a> <var>animateFunction</var> with arguments «<var>timelines</var>, <var>effect</var>»,
     and with <var>instance</var> as the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>.</p>
@@ -1743,14 +1743,12 @@ in the same frame.
    <p class="issue" id="issue-216cac5b"><a class="self-link" href="#issue-216cac5b"></a> Define when we may get rid of the animator.</p>
    <h3 class="heading settled" data-level="7.4" id="requesting-animation-frames"><span class="secno">7.4. </span><span class="content">Requesting Animation Frames</span><a class="self-link" href="#requesting-animation-frames"></a></h3>
    <p>Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-7">animator instance</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animation-requested-flag">animation requested flag</dfn>. It must be
-either <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-requested">frame-requested</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-current">frame-current</dfn>. It is initially set to <a data-link-type="dfn">frame-
-current</a>. Various events, for example changes in of the animator’s <a data-link-type="dfn" href="#animator-timelines-list" id="ref-for-animator-timelines-list-2">animator timelines
-list</a> currentTime can cause the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-5">animation requested flag</a> to be set to <a data-link-type="dfn">frame-
-requested</a>.</p>
-   <p><a href="#running-animators">§7.2 Running Animators</a> resets the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-6">animation requested flag</a> on animators to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-3">frame-current</a>.</p>
+either <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-requested">frame-requested</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-current">frame-current</dfn>. It is initially set to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-3">frame-current</a>. Various events, for example changes in of the animator’s <a data-link-type="dfn" href="#animator-timelines-list" id="ref-for-animator-timelines-list-2">animator
+timelines list</a> currentTime can cause the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-5">animation requested flag</a> to be set to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-2">frame-requested</a>.</p>
+   <p><a href="#running-animators">§7.2 Running Animators</a> resets the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-6">animation requested flag</a> on animators to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-4">frame-current</a>.</p>
    <h2 class="heading settled" data-level="8" id="integration-web-animation"><span class="secno">8. </span><span class="content">Integration With Web Animations</span><a class="self-link" href="#integration-web-animation"></a></h2>
    <h3 class="heading settled" data-level="8.1" id="creating-worklet-animation"><span class="secno">8.1. </span><span class="content">Creating an Worklet Animation</span><a class="self-link" href="#creating-worklet-animation"></a></h3>
-    TODO: 
+   <p>TODO:</p>
    <ul>
     <li data-md="">
      <p>add IDL for worklet animation</p>
@@ -1764,13 +1762,13 @@ requested</a>.</p>
      <p>define what it means when localTime is read on this instance (i.e., we get last value synced
 from worklet scope)</p>
    </ul>
-   <p class="issue" id="issue-c2cb2c27"><a class="self-link" href="#issue-c2cb2c27"></a> describe how constructor handles single or sequence of effects
-Issue(63): define new semantics for reverse/finish/playbackRate</p>
+   <p class="issue" id="issue-fb4f14aa"><a class="self-link" href="#issue-fb4f14aa"></a> describe how constructor handles single or sequence of effects. <a href="https://github.com/majido/animation-worklet/issues/62">&lt;https://github.com/majido/animation-worklet/issues/62></a></p>
+   <p class="issue" id="issue-60474131"><a class="self-link" href="#issue-60474131"></a> define worklet animation appropriate semantics for reverse/finish/playbackRate. <a href="https://github.com/majido/animation-worklet/issues/63">&lt;https://github.com/majido/animation-worklet/issues/63></a></p>
    <h3 class="heading settled" data-level="8.2" id="timeline-attachment"><span class="secno">8.2. </span><span class="content">Timeline Attachment</span><a class="self-link" href="#timeline-attachment"></a></h3>
-   <p>TODO</p>
-   <p class="issue" id="issue-8cedaea7"><a class="self-link" href="#issue-8cedaea7"></a> Define semantics of attachment and detachment</p>
+   <p>TODO:</p>
+   <p class="issue" id="issue-8cedaea7"><a class="self-link" href="#issue-8cedaea7"></a> Define semantics of attachment and detachment <a href="https://github.com/majido/animation-worklet/issues/61">&lt;https://github.com/majido/animation-worklet/issues/61></a></p>
    <h3 class="heading settled" data-level="8.3" id="worklet-group-effect"><span class="secno">8.3. </span><span class="content">WorkletGroupEffect</span><a class="self-link" href="#worklet-group-effect"></a></h3>
-    TODO: 
+   <p>TODO:</p>
    <ul>
     <li data-md="">
      <p>Add idl for worklet group effect</p>
@@ -1778,7 +1776,7 @@ Issue(63): define new semantics for reverse/finish/playbackRate</p>
      <p>define the children start time schedule for the group effect. [Issue](https://github.com/w3c/web-animations/issues/191)</p>
    </ul>
    <h3 class="heading settled" data-level="8.4" id="timing-model"><span class="secno">8.4. </span><span class="content">WorkletAnimation timing model</span><a class="self-link" href="#timing-model"></a></h3>
-    TODO: 
+   <p>TODO:</p>
    <ul>
     <li data-md="">
      <p>Describe the relation of WorkletAnimation.currentTime with its timeline time</p>
@@ -1798,13 +1796,13 @@ composite operation is not in scope at this point.</p>
    <h2 class="heading settled" data-level="11" id="examples"><span class="secno">11. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <h3 class="heading settled" data-level="11.1" id="example-1"><span class="secno">11.1. </span><span class="content">Example 1: Hidey Bar.</span><a class="self-link" href="#example-1"></a></h3>
     An example of header effect where a header is moved with scroll and as soon as finger is lifted it animates fully to close or open position depending on its current position. 
-<pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'scrollingContainer'</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'header'</span><span class="p">></span>Some header<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span><span class="p">></span>content<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+<pre class="lang-markup highlight"><span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">'scrollingContainer'</span><span class="nt">></span>
+  <span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">'header'</span><span class="nt">></span>Some header<span class="nt">&lt;/div></span>
+  <span class="nt">&lt;div></span>content<span class="nt">&lt;/div></span>
+<span class="nt">&lt;/div></span>
 
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'hidey-bar-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="p">=></span> <span class="p">{</span>
+<span class="nt">&lt;script></span>
+animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'hidey-bar-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="o">=></span> <span class="p">{</span>
   <span class="kr">const</span> scrollTimeline <span class="o">=</span> <span class="k">new</span> ScrollTimeline<span class="p">(</span>$scrollingContainer<span class="p">,</span> <span class="p">{</span>timeRange<span class="o">:</span> <span class="mi">100</span><span class="p">});</span>
 
   <span class="kd">var</span> workletAnim <span class="o">=</span> <span class="k">new</span> WorkletAnimation<span class="p">(</span><span class="s1">'hidey-bar'</span><span class="p">,</span>
@@ -1818,7 +1816,7 @@ animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span c
 
 workletAnim<span class="p">.</span>timeline <span class="o">==</span> scrollTimeline<span class="p">;</span> <span class="c1">// true, timeline returns the primary timeline</span>
 <span class="c1"></span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 </pre>
 <pre class="lang-javascript highlight"><span class="c1">// Inside AnimationWorkletGlobalScope</span>
 <span class="c1"></span>
@@ -1847,7 +1845,7 @@ registerAnimator<span class="p">(</span><span class="s1">'hidey-bar'</span><span
   <span class="p">}</span>
 <span class="p">});</span>
 </pre>
-   <p class="issue" id="issue-e1ad2274"><a class="self-link" href="#issue-e1ad2274"></a> This example uses a hypothetical <a class="property" data-link-type="propdesc">phase</a> property on timeline as a way to detect when user
+   <p class="issue" id="issue-2eb87a7a"><a class="self-link" href="#issue-2eb87a7a"></a> This example uses a hypothetical "phase" property on timeline as a way to detect when user
 is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
 fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
 the last few frames.</p>
@@ -1855,13 +1853,13 @@ the last few frames.</p>
     An example of twitter profile header effect where two elements (avatar, and header) are updated in
 sync with scroll offset. 
 <pre class="lang-markup highlight">// In document scope
-<span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'scrollingContainer'</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'header'</span> <span class="na">style</span><span class="o">=</span><span class="s">'height: 150px'</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'avatar'</span><span class="p">>&lt;</span><span class="nt">img</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+<span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">'scrollingContainer'</span><span class="nt">></span>
+  <span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">'header'</span> <span class="na">style=</span><span class="s">'height: 150px'</span><span class="nt">>&lt;/div></span>
+  <span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">'avatar'</span><span class="nt">>&lt;img>&lt;/div></span>
+<span class="nt">&lt;/div></span>
 
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'twitter-header-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="p">=></span> <span class="p">{</span>
+<span class="nt">&lt;script></span>
+animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'twitter-header-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="o">=></span> <span class="p">{</span>
   <span class="kr">const</span> workletAnim <span class="o">=</span> <span class="k">new</span> WorkletAnimation<span class="p">(</span><span class="s1">'twitter-header'</span><span class="p">,</span>
     <span class="p">[</span><span class="k">new</span> KeyFrameEffect<span class="p">(</span>$avatar<span class="p">,</span>  <span class="cm">/* scales down as we scroll up */</span>
                         <span class="p">[{</span>transform<span class="o">:</span> <span class="s1">'scale(1)'</span><span class="p">},</span> <span class="p">{</span>transform<span class="o">:</span> <span class="s1">'scale(0.5)'</span><span class="p">}],</span>
@@ -1876,7 +1874,7 @@ animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span c
 <span class="c1"></span>  workletAnim <span class="o">==</span> $avatarEl<span class="p">.</span>getAnimations<span class="p">()[</span><span class="mi">0</span><span class="p">]</span> <span class="o">==</span> $headerEl<span class="p">.</span>getAnimations<span class="p">()[</span><span class="mi">0</span><span class="p">];</span>
 
 <span class="p">});</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 </pre>
 <pre class="lang-javascript highlight"><span class="c1">// Ins AnimationWorkletGlobalScope.</span>
 <span class="c1"></span>registerAnimator<span class="p">(</span><span class="s1">'twitter-header'</span><span class="p">,</span> <span class="kr">class</span> <span class="p">{</span>
@@ -2056,10 +2054,10 @@ animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span c
    <li><a href="#dom-window-animationworklet">animationWorklet</a><span>, in §4</span>
    <li><a href="#animationworkletglobalscope">AnimationWorkletGlobalScope</a><span>, in §4</span>
    <li><a href="#animator-definition">animator definition</a><span>, in §5</span>
+   <li><a href="#animator-effect">animator effect</a><span>, in §5</span>
    <li><a href="#animator-instance">animator instance</a><span>, in §5</span>
    <li><a href="#animator-name">animator name</a><span>, in §5</span>
    <li><a href="#animator-name-to-animator-definition-map">animator name to animator definition map</a><span>, in §6</span>
-   <li><a href="#animator-output-effect">animator output effect</a><span>, in §5</span>
    <li><a href="#animator-timelines-list">animator timelines list</a><span>, in §5</span>
    <li><a href="#class-constructor">class constructor</a><span>, in §5</span>
    <li><a href="#create-a-new-animator-instance">create a new animator instance</a><span>, in §7.1</span>
@@ -2160,19 +2158,19 @@ animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span c
    <div class="issue"> Consider giving user agents permission to skip running animator instances to
     throttle slow animators.<a href="#issue-07876098"> ↵ </a></div>
    <div class="issue"> Define when we may get rid of the animator.<a href="#issue-216cac5b"> ↵ </a></div>
-   <div class="issue"> describe how constructor handles single or sequence of effects
-Issue(63): define new semantics for reverse/finish/playbackRate<a href="#issue-c2cb2c27"> ↵ </a></div>
-   <div class="issue"> Define semantics of attachment and detachment<a href="#issue-8cedaea7"> ↵ </a></div>
+   <div class="issue"> describe how constructor handles single or sequence of effects. <a href="https://github.com/majido/animation-worklet/issues/62">&lt;https://github.com/majido/animation-worklet/issues/62></a><a href="#issue-fb4f14aa"> ↵ </a></div>
+   <div class="issue"> define worklet animation appropriate semantics for reverse/finish/playbackRate. <a href="https://github.com/majido/animation-worklet/issues/63">&lt;https://github.com/majido/animation-worklet/issues/63></a><a href="#issue-60474131"> ↵ </a></div>
+   <div class="issue"> Define semantics of attachment and detachment <a href="https://github.com/majido/animation-worklet/issues/61">&lt;https://github.com/majido/animation-worklet/issues/61></a><a href="#issue-8cedaea7"> ↵ </a></div>
    <div class="issue"> Worklet animations will have a special animation class that  ranks them with the highest
 order in animation stack effect. also their composite operation is "replace" which is going to
 allow them to run in parallel to other web animations in the system. Supporting other
 composite operation is not in scope at this point.<a href="#issue-8d2c2dd1"> ↵ </a></div>
    <div class="issue"> Need to decide what security considerations there are for this spec.<a href="#issue-de770110"> ↵ </a></div>
    <div class="issue"> Need to decide what privacy considerations there are for this spec.<a href="#issue-19f9ed9b"> ↵ </a></div>
-   <div class="issue"> This example uses a hypothetical <a class="property" data-link-type="propdesc">phase</a> property on timeline as a way to detect when user
+   <div class="issue"> This example uses a hypothetical "phase" property on timeline as a way to detect when user
 is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
 fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
-the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
+the last few frames.<a href="#issue-2eb87a7a"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="animation-worklet">
    <b><a href="#animation-worklet">#animation-worklet</a></b><b>Referenced in:</b>
@@ -2241,10 +2239,11 @@ the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
     <li><a href="#ref-for-animator-instance-7">7.4. Requesting Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-output-effect">
-   <b><a href="#animator-output-effect">#animator-output-effect</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="animator-effect">
+   <b><a href="#animator-effect">#animator-effect</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-animator-output-effect-1">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animator-effect-1">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animator-effect-2">7.2. Running Animators</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-timelines-list">
@@ -2257,7 +2256,7 @@ the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
   <aside class="dfn-panel" data-for="timeline">
    <b><a href="#timeline">#timeline</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-timeline-1">5. Concepts</a>
+    <li><a href="#ref-for-timeline-1">5. Concepts</a> <a href="#ref-for-timeline-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-name-to-animator-definition-map">
@@ -2301,6 +2300,7 @@ the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
    <b><a href="#frame-requested">#frame-requested</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-requested-1">7.2. Running Animators</a>
+    <li><a href="#ref-for-frame-requested-2">7.4. Requesting Animation Frames</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="frame-current">
@@ -2308,7 +2308,7 @@ the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-frame-current-1">7.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-frame-current-2">7.2. Running Animators</a>
-    <li><a href="#ref-for-frame-current-3">7.4. Requesting Animation Frames</a>
+    <li><a href="#ref-for-frame-current-3">7.4. Requesting Animation Frames</a> <a href="#ref-for-frame-current-4">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1424,7 +1424,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Animation Worklet API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-20">20 July 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-07-21">21 July 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1467,28 +1467,31 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#animation-worklet-desc"><span class="secno">4</span> <span class="content">Animation Worklet</span></a>
     <li><a href="#concepts"><span class="secno">5</span> <span class="content">Concepts</span></a>
     <li><a href="#registering-animator-definition"><span class="secno">6</span> <span class="content">Registering an Animator Definition</span></a>
-    <li><a href="#creating-animator"><span class="secno">7</span> <span class="content">Creating an Animator</span></a>
-    <li><a href="#creating-element-proxy"><span class="secno">8</span> <span class="content">Creating an Element Proxy</span></a>
     <li>
-     <a href="#requesting-animation-frames"><span class="secno">9</span> <span class="content">Requesting Animation Frames</span></a>
+     <a href="#animator-instance0"><span class="secno">7</span> <span class="content">Animator Instance</span></a>
      <ol class="toc">
-      <li><a href="#requesting-animation-frames-element-proxy"><span class="secno">9.1</span> <span class="content">Element proxy creation/removal</span></a>
-      <li><a href="#requesting-animation-frames-computed-style"><span class="secno">9.2</span> <span class="content">Change in an element’s computed style</span></a>
-      <li><a href="#requesting-animation-frames-document-timeline"><span class="secno">9.3</span> <span class="content">Animator specifies a DocumentTimeline</span></a>
-      <li><a href="#requesting-animation-frames-scroll-timeline"><span class="secno">9.4</span> <span class="content">Animator specifies a ScrollTimeline</span></a>
+      <li><a href="#creating-animator-instance"><span class="secno">7.1</span> <span class="content">Creating an Animator Instance</span></a>
+      <li><a href="#running-animators"><span class="secno">7.2</span> <span class="content">Running Animators</span></a>
+      <li><a href="#removing-animator"><span class="secno">7.3</span> <span class="content">Removing an Animator</span></a>
+      <li><a href="#requesting-animation-frames"><span class="secno">7.4</span> <span class="content">Requesting Animation Frames</span></a>
      </ol>
-    <li><a href="#running-animators"><span class="secno">10</span> <span class="content">Running Animators</span></a>
-    <li><a href="#closing-animator"><span class="secno">11</span> <span class="content">Closing an Animator</span></a>
-    <li><a href="#css-animator-notation"><span class="secno">12</span> <span class="content">CSS Animator Notation</span></a>
-    <li><a href="#effect-stack"><span class="secno">13</span> <span class="content">Effect Stack</span></a>
-    <li><a href="#security-considerations"><span class="secno">14</span> <span class="content">Security Considerations</span></a>
-    <li><a href="#privacy-considerations"><span class="secno">15</span> <span class="content">Privacy Considerations</span></a>
     <li>
-     <a href="#examples"><span class="secno">16</span> <span class="content">Examples</span></a>
+     <a href="#integration-web-animation"><span class="secno">8</span> <span class="content">Integration With Web Animations</span></a>
      <ol class="toc">
-      <li><a href="#example-1"><span class="secno">16.1</span> <span class="content">Example 1: A fade-in animation with spring timing.</span></a>
-      <li><a href="#example-2"><span class="secno">16.2</span> <span class="content">Example 2: Twitter header.</span></a>
-      <li><a href="#example-3"><span class="secno">16.3</span> <span class="content">Example 3: Parallax backgrounds.</span></a>
+      <li><a href="#creating-worklet-animation"><span class="secno">8.1</span> <span class="content">Creating an Worklet Animation</span></a>
+      <li><a href="#timeline-attachment"><span class="secno">8.2</span> <span class="content">Timeline Attachment</span></a>
+      <li><a href="#worklet-group-effect"><span class="secno">8.3</span> <span class="content">WorkletGroupEffect</span></a>
+      <li><a href="#timing-model"><span class="secno">8.4</span> <span class="content">WorkletAnimation timing model</span></a>
+      <li><a href="#effect-stack"><span class="secno">8.5</span> <span class="content">Effect Stack</span></a>
+     </ol>
+    <li><a href="#security-considerations"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
+    <li><a href="#privacy-considerations"><span class="secno">10</span> <span class="content">Privacy Considerations</span></a>
+    <li>
+     <a href="#examples"><span class="secno">11</span> <span class="content">Examples</span></a>
+     <ol class="toc">
+      <li><a href="#example-1"><span class="secno">11.1</span> <span class="content">Example 1: Hidey Bar.</span></a>
+      <li><a href="#example-2"><span class="secno">11.2</span> <span class="content">Example 2: Twitter header.</span></a>
+      <li><a href="#example-3"><span class="secno">11.3</span> <span class="content">Example 3: Parallax backgrounds.</span></a>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
@@ -1503,7 +1506,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
-    <li><a href="#property-index"><span class="secno"></span> <span class="content">Property Index</span></a>
     <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
     <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ol>
@@ -1516,7 +1518,7 @@ changes to the AnimationWorklet API</strong>.
    <h2 class="heading settled" data-level="2" id="intro"><span class="secno">2. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
     This document introduces a new primitive for creating scroll-linked and other high performance
 procedural animations on the web. For details on the rationale and motivation see <a data-link-type="biblio" href="#biblio-explainer">[explainer]</a>. 
-   <p>The <a data-link-type="dfn" href="#animation-worklet" id="ref-for-animation-worklet-1">Animation Worklet</a> provides a method to create scripted animations that control a set of <a data-link-type="dfn">animation effects</a>. The API is designed to make it possible for user agents to run such
+   <p>The <a data-link-type="dfn" href="#animation-worklet" id="ref-for-animation-worklet-1">Animation Worklet</a> provides a method to create scripted animations that control a set of <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#animation-effect">animation effects</a>. The API is designed to make it possible for user agents to run such
 animations to run in their own dedicated thread to provide a degree of performance isolation
 from main thread.</p>
    <p><strong>Relationship to Web Animation API</strong>: Animations that are running inside a <a data-link-type="dfn" href="#animation-worklet" id="ref-for-animation-worklet-2">Animation Worklet</a> execution context expose the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/web-animations/#animation">Animation</a></code> interface on the main
@@ -1558,656 +1560,345 @@ offsets on main thread.</p>
     <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animation-worklet">Animation Worklet</dfn> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#worklet">Worklet</a></code> responsible for all classes related to custom
 animations. The worklet can be accessed via <code class="idl"><a data-link-type="idl" href="#dom-window-animationworklet" id="ref-for-dom-window-animationworklet-1">animationWorklet</a></code> attribute. 
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-window-animationworklet" id="ref-for-dom-window-animationworklet-2">animationWorklet</a></code>'s <a data-link-type="dfn" href="https://drafts.css-houdini.org/worklets/#worklet-global-scope-type">worklet global scope type</a> is <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-1">AnimationWorkletGlobalScope</a></code>.</p>
-<pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="animationworklet"><code>AnimationWorklet</code></dfn> {
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <dfn class="nv idl-code" data-dfn-for="AnimationWorklet" data-dfn-type="method" data-export="" data-lt="addModule(moduleURL)" id="dom-animationworklet-addmodule"><code>addModule</code><a class="self-link" href="#dom-animationworklet-addmodule"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="AnimationWorklet/addModule(moduleURL)" data-dfn-type="argument" data-export="" id="dom-animationworklet-addmodule-moduleurl-moduleurl"><code>moduleURL</code><a class="self-link" href="#dom-animationworklet-addmodule-moduleurl-moduleurl"></a></dfn>);
-};
-
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a> {
-    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#animationworklet" id="ref-for-animationworklet-1">AnimationWorklet</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export="" data-readonly="" data-type="AnimationWorklet" id="dom-window-animationworklet"><code>animationWorklet</code></dfn>;
+   <p>The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-2">AnimationWorkletGlobalScope</a></code> represents the <dfn data-dfn-type="dfn" data-noexport="" id="global-execution-context">global execution context<a class="self-link" href="#global-execution-context"></a></dfn> of <code class="idl"><a data-link-type="idl" href="#dom-window-animationworklet" id="ref-for-dom-window-animationworklet-3">animationWorklet</a></code>.</p>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a> {
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/worklets/#worklet">Worklet</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Worklet" id="dom-window-animationworklet"><code>animationWorklet</code></dfn>;
 };
 </pre>
 <pre class="idl highlight def"><span class="kt">callback</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="callback" data-export="" id="callbackdef-voidfunction"><code>VoidFunction</code></dfn> = <span class="kt">void</span> ();
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">AnimationWorklet</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="animationworkletglobalscope"><code>AnimationWorkletGlobalScope</code></dfn> : <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/worklets/#workletglobalscope">WorkletGlobalScope</a> {
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-animationworkletglobalscope-registeranimator" id="ref-for-dom-animationworkletglobalscope-registeranimator-1">registerAnimator</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="AnimationWorkletGlobalScope/registerAnimator(name, animatorCtor)" data-dfn-type="argument" data-export="" id="dom-animationworkletglobalscope-registeranimator-name-animatorctor-name"><code>name</code><a class="self-link" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-name"></a></dfn>, <a class="n" data-link-type="idl-name" href="#callbackdef-voidfunction" id="ref-for-callbackdef-voidfunction-1">VoidFunction</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="AnimationWorkletGlobalScope/registerAnimator(name, animatorCtor)" data-dfn-type="argument" data-export="" id="dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor"><code>animatorCtor</code></dfn>);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-animationworkletglobalscope-registeranimator" id="ref-for-dom-animationworkletglobalscope-registeranimator-1">registerAnimator</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="AnimationWorkletGlobalScope/registerAnimator(name, animatorCtor)" data-dfn-type="argument" data-export="" id="dom-animationworkletglobalscope-registeranimator-name-animatorctor-name"><code>name</code><a class="self-link" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-name"></a></dfn>, <a class="n" data-link-type="idl-name" href="#callbackdef-voidfunction" id="ref-for-callbackdef-voidfunction-1">VoidFunction</a> <dfn class="nv idl-code" data-dfn-for="AnimationWorkletGlobalScope/registerAnimator(name, animatorCtor)" data-dfn-type="argument" data-export="" id="dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor"><code>animatorCtor</code><a class="self-link" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor"></a></dfn>);
 };
 </pre>
    <div class="note" role="note">
      Note: This is how the class should look. 
 <pre class="lang-javascript highlight"><span class="kr">class</span> FooAnimator <span class="p">{</span>
-    <span class="kr">static</span> get elements<span class="p">()</span> <span class="p">{</span>
-        <span class="k">return</span> <span class="p">[</span>
-            <span class="p">{</span>name<span class="o">:</span> <span class="s1">'foo'</span><span class="p">,</span> inputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'--foo'</span><span class="p">],</span> outputProperties<span class="o">:</span> <span class="p">[]},</span>
-            <span class="p">{</span>name<span class="o">:</span> <span class="s1">'bar'</span><span class="p">,</span> inputProperties<span class="o">:</span> <span class="p">[],</span> outputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'transform'</span><span class="p">]},</span>
-        <span class="p">];</span>
-    <span class="p">};</span>
-
-    <span class="kr">static</span> timelines <span class="o">=</span> <span class="p">[</span>
-        <span class="s1">'document'</span><span class="p">,</span>
-        <span class="p">{</span> type<span class="o">:</span> <span class="s1">'scroll'</span><span class="p">,</span> <span class="p">{</span> orientation<span class="o">:</span> <span class="s1">'vertical'</span> <span class="p">}</span> <span class="p">},</span>
-    <span class="p">];</span>
-
+    constructor<span class="p">(</span>options<span class="p">)</span> <span class="p">{</span>
+        <span class="c1">// Called when a new animator is instantiated.</span>
+<span class="c1"></span>    <span class="p">}</span>
     animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// Animation frame logic goes here</span>
+        <span class="c1">// Animation frame logic goes here.</span>
 <span class="c1"></span>    <span class="p">}</span>
 <span class="p">}</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="5" id="concepts"><span class="secno">5. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
-    A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-definition">animator definition</dfn> describes an author defined animation which can be referenced by
-an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-1">animator instance</a>. It consists of: 
-   <ul>
-    <li data-md="">
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="class-constructor">class constructor</dfn>.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animate-function">animate function</dfn>.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-slot-list">animator slot list</dfn> containing a dictionary providing each <dfn data-dfn-type="dfn" data-noexport="" id="slot-name">slot name<a class="self-link" href="#slot-name"></a></dfn>,
-its <dfn data-dfn-type="dfn" data-noexport="" id="input-property-list">input property list<a class="self-link" href="#input-property-list"></a></dfn>, and its <dfn data-dfn-type="dfn" data-noexport="" id="output-property-list">output property list<a class="self-link" href="#output-property-list"></a></dfn>.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-timeline-options-list">animator timeline options list</dfn>.</p>
-   </ul>
-   <p>Each entry in the <a data-link-type="dfn" href="#animator-slot-list" id="ref-for-animator-slot-list-1">animator slot list</a> consists of:</p>
-   <ul>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-slot">animator slot</dfn> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>#.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-input-property-list">animator input property list</dfn>.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-output-property-list">animator output property list</dfn>.</p>
-   </ul>
-   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-instance">animator instance</dfn> describes a fully realized custom animation instance in the worklet
-context and links an <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-1">animator definition</a> with the instance specific state such as its element
-proxies. It consists of:</p>
+    An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-definition">animator definition</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct">struct</a> which describes the author defined custom
+animation as needed by <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-3">AnimationWorkletGlobalScope</a></code>. It consists of: 
    <ul>
     <li data-md="">
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-name">animator name</dfn> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>#.</p>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-1">animation requested flag</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="class-constructor">class constructor</dfn>.</p>
     <li data-md="">
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element</dfn>.</p>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="element-proxy-map">element proxy map</dfn> mapping <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-1">animator slot</a> to a list of <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-1">element proxies</a>.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animate-function">animate function</dfn>.</p>
    </ul>
-   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="element-proxy">element proxy</dfn> defines a handle to an element which can be used to read or
-write its explicitly exposed animatable attributes. It consists of:</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-instance">animator instance</dfn> a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct">struct</a> which describes a fully realized custom animation
+instance in the <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-4">AnimationWorkletGlobalScope</a></code>. It has a reference to an <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-1">animator
+definition</a> and owns the instance specific state such as animation effects and timelines. It
+consists of:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-2">animator instance</a>.</p>
+     <p>An <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-1">animator name</a>.</p>
     <li data-md="">
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="proxied-element">proxied element</dfn>.</p>
+     <p>An <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-1">animation requested flag</a>.</p>
     <li data-md="">
-     <p>A read only map of proxied input properties to their values.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-output-effect">animator output effect</dfn>.</p>
     <li data-md="">
-     <p>A map of proxied output properties to their values.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-timelines-list">animator timelines list</dfn>.</p>
+   </ul>
+   <p>An <dfn data-dfn-type="dfn" data-noexport="" id="worklet-animation">worklet animation<a class="self-link" href="#worklet-animation"></a></dfn> is a <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#concept-animation">animation</a> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a> which may corresponds
+to an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-1">animator instance</a> in the <a data-link-type="dfn">worklet global scope</a>. It provides playback control
+and controls the lifetime of its corresponding <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-2">animator instance</a>. It
+consists of:</p>
+   <ul>
+    <li data-md="">
+     <p>An <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-2">animator name</a>.</p>
+    <li data-md="">
+     <p>An <dfn data-dfn-type="dfn" data-noexport="" id="effect">effect<a class="self-link" href="#effect"></a></dfn> which is an <a data-link-type="dfn" href="https://w3c.github.io/web-animations/#animation-effect">animation effect</a>.</p>
+    <li data-md="">
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="timeline">timeline</dfn> which is a <a data-link-type="dfn" href="#timeline" id="ref-for-timeline-1">timeline</a>.</p>
    </ul>
    <h2 class="heading settled" data-level="6" id="registering-animator-definition"><span class="secno">6. </span><span class="content">Registering an Animator Definition</span><a class="self-link" href="#registering-animator-definition"></a></h2>
-    The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-2">AnimationWorkletGlobalScope</a></code> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-name-to-animator-definition-map">animator name to animator definition map</dfn>.
+    The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-5">AnimationWorkletGlobalScope</a></code> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animator-name-to-animator-definition-map">animator name to animator definition map</dfn>.
 The map gets populated when <code class="idl"><a data-link-type="idl" href="#dom-animationworkletglobalscope-registeranimator" id="ref-for-dom-animationworkletglobalscope-registeranimator-2">registerAnimator(name, animatorCtor)</a></code> is called. 
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="AnimationWorkletGlobalScope" data-dfn-type="method" data-export="" data-lt="registerAnimator(name, animatorCtor)" id="dom-animationworkletglobalscope-registeranimator"><code>registerAnimator(<var>name</var>, <var>animatorCtor</var>)</code></dfn> method is called, the user agent <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>If the <var>name</var> is not a valid <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these
+   <div class="algorithm" data-algorithm="register-animator">
+    <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="AnimationWorkletGlobalScope" data-dfn-type="method" data-export="" data-lt="registerAnimator(name, animatorCtor)" id="dom-animationworkletglobalscope-registeranimator"><code>registerAnimator(<var>name</var>, <var>animatorCtor</var>)</code></dfn> method is called, the user agent <em>must</em> run the following steps:</p>
+    <ol>
+     <li data-md="">
+      <p>If the <var>name</var> is not a valid <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these
 steps.</p>
-    <li data-md="">
-     <p>If the <var>name</var> exists as a key in the <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-1">animator name to animator definition map</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a> and abort all these steps.</p>
-    <li data-md="">
-     <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a>(<var>animatorCtor</var>) is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these steps.</p>
-    <li data-md="">
-     <p>Let <var>prototype</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>animatorCtor</var>, "prototype").</p>
-    <li data-md="">
-     <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>prototype</var>) is not Object, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these steps.</p>
-    <li data-md="">
-     <p>Let <var>animate</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>prototype</var>, "animate").</p>
-    <li data-md="">
-     <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>animate</var>) is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and
+     <li data-md="">
+      <p>If the <var>name</var> exists as a key in the <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-1">animator name to animator definition map</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a> and abort all these steps.</p>
+     <li data-md="">
+      <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a>(<var>animatorCtor</var>) is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these steps.</p>
+     <li data-md="">
+      <p>Let <var>prototype</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>animatorCtor</var>, "prototype").</p>
+     <li data-md="">
+      <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>prototype</var>) is not Object, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and abort all these steps.</p>
+     <li data-md="">
+      <p>Let <var>animate</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>prototype</var>, "animate").</p>
+     <li data-md="">
+      <p>If the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(<var>animate</var>) is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a> and
 abort all these steps.</p>
-    <li data-md="">
-     <p>Let <var>elements</var> be the result of <a data-link-type="dfn" href="#parsing-an-animator-slot-list" id="ref-for-parsing-an-animator-slot-list-1">parsing an animator slot list</a> for <var>animatorCtor</var>.
-If an exception is thrown, rethrow the exception and abort all these steps.</p>
-    <li data-md="">
-     <p>Let <var>timelineOptions</var> be the result of <a data-link-type="dfn" href="#parsing-an-animator-timeline-options-list" id="ref-for-parsing-an-animator-timeline-options-list-1">parsing an animator timeline options list</a> for <var>animatorCtor</var>. If an exception is thrown, rethrow the exception and abort all these steps.</p>
-    <li data-md="">
-     <p>Let <var>definition</var> be a new <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-2">animator definition</a> with:</p>
-     <ul>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-1">animator name</a> being <var>name</var></p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#class-constructor" id="ref-for-class-constructor-1">class constructor</a> being <var>animatorCtor</var></p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-1">animate function</a> being <var>animate</var></p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#element-proxy-map" id="ref-for-element-proxy-map-1">element proxy map</a> being <var>elements</var></p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#animator-timeline-options-list" id="ref-for-animator-timeline-options-list-1">animator timeline options list</a> being <var>timelineOptions</var></p>
-     </ul>
-    <li data-md="">
-     <p>Add the key-value pair (<var>name</var> - <var>definition</var>) to the <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-2">animator name to animator
+     <li data-md="">
+      <p>Let <var>definition</var> be a new <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-2">animator definition</a> with:</p>
+      <ul>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-3">animator name</a> being <var>name</var></p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#class-constructor" id="ref-for-class-constructor-1">class constructor</a> being <var>animatorCtor</var></p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-1">animate function</a> being <var>animate</var></p>
+      </ul>
+     <li data-md="">
+      <p>Add the key-value pair (<var>name</var> - <var>definition</var>) to the <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-2">animator name to animator
 definition map</a> of the associated <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
-   </ol>
-   <p>When <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parsing-an-animator-slot-list">parsing an animator slot list</dfn> for <code class="idl"><a data-link-type="idl" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor" id="ref-for-dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor-1">animatorCtor</a></code>, the user agent <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>elements</var> be an empty <code>sequence&lt;Dictionary></code>.</p>
-    <li data-md="">
-     <p>Let <var>elementsIterable</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>animatorCtor</var>, <var>elements</var>).</p>
-    <li data-md="">
-     <p>If <var>elementsIterable</var> is not <em>undefined</em>, then for each <var>slot</var> in <var>elementsIterable</var> run the
-following steps:</p>
-     <ul>
-      <li data-md="">
-       <p>Let <var>slotDictionary</var> be an empty dictionary.</p>
-      <li data-md="">
-       <p>Let the <var>name</var> key of <var>slotDictionary</var> be the <var>name</var> value of <var>element</var>.</p>
-      <li data-md="">
-       <p>Let the <var>inputProperties</var> key of <var>slotDictionary</var> be the result of <a data-link-type="dfn" href="#parsing-an-animator-property-list" id="ref-for-parsing-an-animator-property-list-1">parsing an animator property list</a> with name <em>inputProperties</em> for <var>slot</var>.</p>
-      <li data-md="">
-       <p>Let the <var>outputProperties</var> key of <var>slotDictionary</var> be the result of <a data-link-type="dfn" href="#parsing-an-animator-property-list" id="ref-for-parsing-an-animator-property-list-2">parsing an animator property list</a> with name <em>outputProperties</em> for <var>slot</var>.</p>
-      <li data-md="">
-       <p>Push <var>slotDictionary</var> onto <var>elements</var>.</p>
-     </ul>
-   </ol>
-   <p>When <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parsing-an-animator-property-list">parsing an animator property list</dfn> with name <em>name</em> for <em>slot</em>,
+    </ol>
+   </div>
+   <h2 class="heading settled" data-level="7" id="animator-instance0"><span class="secno">7. </span><span class="content">Animator Instance</span><a class="self-link" href="#animator-instance0"></a></h2>
+   <h3 class="heading settled" data-level="7.1" id="creating-animator-instance"><span class="secno">7.1. </span><span class="content">Creating an Animator Instance</span><a class="self-link" href="#creating-animator-instance"></a></h3>
+   <p>Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-3">animator instance</a> lives in an <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-6">AnimationWorkletGlobalScope</a></code>. The <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-4">animator instance</a> cannot be disposed arbitrarily (e.g., in the middle of running animation
+as it may contain the scripted animation state.</p>
+   <p class="issue" id="issue-8ecade61"><a class="self-link" href="#issue-8ecade61"></a> This is no longer true as we provide destroy callback.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-7">AnimationWorkletGlobalScope</a></code> has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animation-id-to-instance-map">animation id to instance map</dfn>.
+The map is populated when the user agent constructs a new <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-5">animator instance</a> in that scope
+that corresponds to a worklet animation in the document scope.</p>
+   <div class="algorithm" data-algorithm="create-animator">
+    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="create-a-new-animator-instance">create a new animator instance<a class="self-link" href="#create-a-new-animator-instance"></a></dfn> given a <var>name</var>, <var>animationId</var>, <var>timeline</var>, <var>effect</var>, and <var>workletGlobalScope</var>,
 the user agent <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>properties</var> be an empty <code>sequence&lt;DOMString></code>.</p>
-    <li data-md="">
-     <p>Let <var>propertiesIterable</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>slot</var>, <var>name</var>).</p>
-    <li data-md="">
-     <p>If <var>propertiesIterable</var> is not <em>undefined</em>, then set <var>properties</var> to the result of
-converting <var>propertiesIterable</var> to a <code>sequence&lt;DOMString></code>. If an
-exception is thrown, rethrow the exception and abort all these steps.</p>
-   </ol>
-   <p>When <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parsing-an-animator-timeline-options-list">parsing an animator timeline options list</dfn> for <code class="idl"><a data-link-type="idl" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor" id="ref-for-dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor-2">animatorCtor</a></code>,
-the user agent <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>timelineOptions</var> be an empty <code>sequence&lt;Object></code>.</p>
-    <li data-md="">
-     <p>Let <var>timelinesIterable</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>animatorCtor</var>, <var>timelines</var>).</p>
-    <li data-md="">
-     <p>For each <var>timeline</var> in <var>timelinesIterable</var>, run the following steps:</p>
-     <ol>
-      <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>timeline</var>) is <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> let <var>timelineObject</var> be <code>{ type: <var>timeline</var>, options: {} }</code>, otherwise let <var>timelineObject</var> be <var>timeline</var>.</p>
-      <li data-md="">
-       <p>Let <var>type</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>timelineObject</var>, "type").</p>
-      <li data-md="">
-       <p>Let <var>options</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>timelineObject</var>, "options").</p>
-      <li data-md="">
-       <p>Process <var>type</var> and <var>options</var> according to the first matching condition in the following:</p>
-       <div class="switch">
-        <dl>
-         <dt data-md="">If <var>type</var> or <var>options</var> is <b>undefined</b>,
-         <dd data-md="">
-          <p>throw a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a> and abort all remaining steps.</p>
-         <dt data-md="">If <var>type</var> is "document",
-         <dd data-md="">
-          <p>Push a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/web-animations/#dictdef-documenttimelineoptions">DocumentTimelineOptions</a></code> created from <var>options</var> onto <var>timelineOptions</var>.</p>
-         <dt data-md="">If <var>type</var> is "scroll",
-         <dd data-md="">
-          <p>Push a <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dictdef-scrolltimelineoptions">ScrollTimelineOptions</a></code> created from <var>options</var> onto <var>timelineOptions</var>.</p>
-         <dt data-md="">Otherwise,
-         <dd data-md="">
-          <p>throw a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a> and abort all remaining steps.</p>
-        </dl>
-       </div>
-     </ol>
-   </ol>
-   <h2 class="heading settled" data-level="7" id="creating-animator"><span class="secno">7. </span><span class="content">Creating an Animator</span><a class="self-link" href="#creating-animator"></a></h2>
-    Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-3">animator instance</a> lives in an <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-3">AnimationWorkletGlobalScope</a></code>. The <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-4">animator instance</a> cannot be disposed arbitrarily (e.g., in the middle of running animation
-as it may contain the scripted animation state. 
-   <p>The <code class="idl"><a data-link-type="idl" href="#animationworkletglobalscope" id="ref-for-animationworkletglobalscope-4">AnimationWorkletGlobalScope</a></code> has an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="-animator-name-root-element-to-instance-map">(animator name, root element) to instance map</dfn>.
-The map is populated when the user agent constructs a new <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-5">animator instance</a> in that scope.</p>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-a-new-animator-instance">create a new animator instance</dfn> given a <var>name</var>, <var>root element</var>, and <var>workletGlobalScope</var>,
-the user agent <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let the <var>definition</var> be the result of looking up <var>name</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-3">animator name to animator definition map</a>.</p>
-     <p>If <var>definition</var> does not exist abort the following steps.</p>
-    <li data-md="">
-     <p>Let <var>animatorInstanceMap</var> be <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#-animator-name-root-element-to-instance-map" id="ref-for--animator-name-root-element-to-instance-map-1">(animator name, root element) to
+    <ol>
+     <li data-md="">
+      <p>Let the <var>definition</var> be the result of looking up <var>name</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-3">animator name to animator definition map</a>.</p>
+      <p>If <var>definition</var> does not exist abort the following steps.</p>
+     <li data-md="">
+      <p>Let <var>animatorInstanceMap</var> be <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animation-id-to-instance-map" id="ref-for-animation-id-to-instance-map-1">animation id to
  instance map</a>.</p>
-    <li data-md="">
-     <p>If an entry exists for <var>name</var> and <var>root element</var> within <var>animatorInstanceMap</var> then abort the
+     <li data-md="">
+      <p>If an entry exists for <var>animationId</var> within <var>animatorInstanceMap</var> then abort the
  following steps.</p>
-    <li data-md="">
-     <p>Let <var>animatorCtor</var> be the <a data-link-type="dfn" href="#class-constructor" id="ref-for-class-constructor-2">class constructor</a> of <var>definition</var>.</p>
-    <li data-md="">
-     <p>Let <var>animatorInstance</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>animatorCtor</var>).</p>
-     <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a> throws an exception, set the result of looking up <var>name</var> and <var>root element</var> in <var>animatorInstanceMap</var> to <b>null</b>, and abort the following steps.</p>
-    <li data-md="">
-     <p>Set the following on <var>animatorInstance</var> with:</p>
-     <ul>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-2">animator name</a> being <var>name</var></p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-2">animation requested flag</a> being <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-1">frame-current</a></p>
-     </ul>
-    <li data-md="">
-     <p>Set the result of looking up <var>name</var> and <var>root element</var> in <var>animatorInstanceMap</var> to <var>animatorInstance</var>.</p>
-   </ol>
-   <h2 class="heading settled" data-level="8" id="creating-element-proxy"><span class="secno">8. </span><span class="content">Creating an Element Proxy</span><a class="self-link" href="#creating-element-proxy"></a></h2>
-    <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-2">Element Proxy</a> objects are created by the user agent for elements which have either <a class="property" data-link-type="propdesc" href="#propdef-animator" id="ref-for-propdef-animator-1">animator</a> or <a class="property" data-link-type="propdesc" href="#propdef-animator-root" id="ref-for-propdef-animator-root-1">animator-root</a> CSS properties. They cannot be constructed from user script. A single element may
-have multiple <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-3">Element Proxy</a> objects associated with it; one per <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-6">animator instance</a>. 
-   <p>The <code class="idl"><a data-link-type="idl" href="#elementproxy" id="ref-for-elementproxy-1">ElementProxy</a></code> interface exposes two maps: a read only map of proxied input properties to their
-values, and a map of proxied output properties to their values. The input and output properties in
-the maps are those specified in registerAnimator for the given <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-7">animator instance</a>.</p>
-<pre class="idl highlight def">[
-    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">AnimationWorklet</span>),
-] <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="elementproxy"><code>ElementProxy</code></dfn> {
-    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a> <dfn class="nv idl-code" data-dfn-for="ElementProxy" data-dfn-type="attribute" data-export="" data-type="StylePropertyMapReadOnly" id="dom-elementproxy-inputstylemap"><code>inputStyleMap</code><a class="self-link" href="#dom-elementproxy-inputstylemap"></a></dfn>;
-    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ElementProxy" data-dfn-type="attribute" data-export="" data-type="StylePropertyMapReadOnly" id="dom-elementproxy-outputstylemap"><code>outputStyleMap</code></dfn>;
-};
-</pre>
-   <p class="issue" id="issue-65c145a8"><a class="self-link" href="#issue-65c145a8"></a> Todo: Should we have NoInterfaceObject/Exposed here? How do we properly represent that this
-cannot be constructed via javascript?</p>
-   <p>When user agent wants to <dfn data-dfn-type="dfn" data-noexport="" id="create-an-element-proxy">create an element proxy<a class="self-link" href="#create-an-element-proxy"></a></dfn> given <var>element</var> with a given <var>animatorSlot</var>, it <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>animatorInstance</var> be the <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-8">animator instance</a> associated with <var>element</var></p>
-    <li data-md="">
-     <p>Let <var>workletGlobalScope</var> be the scope associated with <var>animatorInstance</var>.</p>
-    <li data-md="">
-     <p>Let <var>definition</var> be the result of looking up <var>name</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-4">animator name to animator definition map</a>.</p>
-    <li data-md="">
-     <p>Let <var>slot</var> be the result of finding the item with name <var>animatorSlot</var> in the <a data-link-type="dfn" href="#animator-slot-list" id="ref-for-animator-slot-list-2">animator slot list</a> of <var>definition</var>.</p>
-    <li data-md="">
-     <p>Let <var>inputProperties</var> be <a data-link-type="dfn" href="#animator-input-property-list" id="ref-for-animator-input-property-list-1">animator input property list</a> of <var>slot</var>.</p>
-    <li data-md="">
-     <p>Let <var>outputProperties</var> be <a data-link-type="dfn" href="#animator-output-property-list" id="ref-for-animator-output-property-list-1">animator output property list</a> of <var>slot</var>.</p>
-    <li data-md="">
-     <p>Let <var>proxy</var> be a new <code class="idl"><a data-link-type="idl" href="#elementproxy" id="ref-for-elementproxy-2">ElementProxy</a></code> Object with:</p>
-     <ul>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="#proxied-element" id="ref-for-proxied-element-1">proxied element</a> being <var>element</var>.</p>
-      <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="#dom-elementproxy-outputstylemap" id="ref-for-dom-elementproxy-outputstylemap-1">outputStyleMap</a></code> being a new <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap">StylePropertyMap</a></code> for <var>outputProperties</var>.</p>
-     </ul>
-    <li data-md="">
-     <p><a data-link-type="dfn" href="#update-proxy-input-style-map" id="ref-for-update-proxy-input-style-map-1">update proxy input style map</a> with <var>proxy</var> and <var>inputProperties</var>.</p>
-    <li data-md="">
-     <p>Associate <var>proxy</var> with <var>animatorInstance</var>.</p>
-    <li data-md="">
-     <p>Return proxy.</p>
-   </ol>
-   <p class="note" role="note"><span>Note:</span> Writing to the outputStyle map will update the effective value of the used style value of the <a data-link-type="dfn" href="#proxied-element" id="ref-for-proxied-element-2">proxied element</a>. This <em>may</em> happen asynchronously.</p>
-   <p>When the user agent wants to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-proxy-input-style-map">update proxy input style map</dfn> given <var>proxy</var>, and <var>properties</var>, it <em>must</em> run the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>styleMap</var> be a new <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a></code> populated with <em>only</em> the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#computed-value">computed value</a> of <a data-link-type="dfn" href="#proxied-element" id="ref-for-proxied-element-3">proxied element</a> for properties listed in <var>properties</var>.</p>
-    <li data-md="">
-     <p>Set <var>proxy</var>’s inputStyleMap to <var>styleMap</var>.</p>
-   </ol>
-   <p>When an element is removed, all proxies of that element are considered to be disconnected.
-A disconnected proxy continues to have the last value from the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#computed-value">computed value</a> of the <a data-link-type="dfn" href="#proxied-element" id="ref-for-proxied-element-4">proxied element</a> properties, but setting values on its outputStyleMap will have no
-effect.</p>
-   <h2 class="heading settled" data-level="9" id="requesting-animation-frames"><span class="secno">9. </span><span class="content">Requesting Animation Frames</span><a class="self-link" href="#requesting-animation-frames"></a></h2>
-    Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-9">animator instance</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animation-requested-flag">animation requested flag</dfn>. It must be
-either <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-requested">frame-requested</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-current">frame-current</dfn>. It is initially set to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-2">frame-current</a>. Various events can cause the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-3">animation requested flag</a> to be set to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-1">frame-requested</a>. 
-   <p><a href="#running-animators">§10 Running Animators</a> resets the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-4">animation requested flag</a> on animators to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-3">frame-current</a>.</p>
-   <h3 class="heading settled" data-level="9.1" id="requesting-animation-frames-element-proxy"><span class="secno">9.1. </span><span class="content">Element proxy creation/removal</span><a class="self-link" href="#requesting-animation-frames-element-proxy"></a></h3>
-   <p>When a new element proxy is assigned to or removed from an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-10">animator instance</a>, that <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-11">animator instance</a>’s <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-5">animation requested flag</a> should be set to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-2">frame-requested</a>.</p>
-   <h3 class="heading settled" data-level="9.2" id="requesting-animation-frames-computed-style"><span class="secno">9.2. </span><span class="content">Change in an element’s computed style</span><a class="self-link" href="#requesting-animation-frames-computed-style"></a></h3>
-   <p>When the computed style for an element changes, the user agent <em>must</em> run the following steps:</p>
-   <p>For each <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-4">element proxy</a> for that element, perform the following steps:</p>
-   <ol>
-    <li data-md="">
-     <p>Let <var>proxy</var> be the current <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-5">element proxy</a> of the element.</p>
-    <li data-md="">
-     <p>Let <var>animator</var> be the <var>proxy</var>’s assigned animator.</p>
-    <li data-md="">
-     <p>Let <var>name</var> be the <var>animator</var>’s name.</p>
-    <li data-md="">
-     <p>Let <var>definition</var> be the result of looking up <var>name</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-5">animator name to animator definition map</a>.</p>
-    <li data-md="">
-     <p>Let <var>slot</var> be the result of finding the item with name <var>animatorSlot</var> in the <a data-link-type="dfn" href="#animator-slot-list" id="ref-for-animator-slot-list-3">animator slot list</a> of <var>definition</var>.</p>
-    <li data-md="">
-     <p>Let <var>inputProperties</var> be <a data-link-type="dfn" href="#animator-input-property-list" id="ref-for-animator-input-property-list-2">animator input property list</a> of <var>slot</var>.</p>
-    <li data-md="">
-     <p>For each property in <var>inputProperties</var>, if the property’s computed value has changed,
-set the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-6">animation requested flag</a> on the <var>animator</var> to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-3">frame-requested</a>.</p>
-   </ol>
-   <h3 class="heading settled" data-level="9.3" id="requesting-animation-frames-document-timeline"><span class="secno">9.3. </span><span class="content">Animator specifies a DocumentTimeline</span><a class="self-link" href="#requesting-animation-frames-document-timeline"></a></h3>
-   <p>If a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/web-animations/#dictdef-documenttimelineoptions">DocumentTimelineOptions</a></code> instance is present in an animator’s <a data-link-type="dfn" href="#animator-timeline-options-list" id="ref-for-animator-timeline-options-list-2">animator timeline options
-list</a> then that animator’s <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-7">animation requested flag</a> <em>must</em> be set to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-4">frame-requested</a> at the start of each animation frame.</p>
-   <h3 class="heading settled" data-level="9.4" id="requesting-animation-frames-scroll-timeline"><span class="secno">9.4. </span><span class="content">Animator specifies a ScrollTimeline</span><a class="self-link" href="#requesting-animation-frames-scroll-timeline"></a></h3>
-   <p>If a <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dictdef-scrolltimelineoptions">ScrollTimelineOptions</a></code> <var>instance</var> is present in an animator’s <a data-link-type="dfn" href="#animator-timeline-options-list" id="ref-for-animator-timeline-options-list-3">animator timeline options
-list</a> then the user agent <em>must</em> run the following steps when the scroll position of the
-nearest non-visible overflow ancestor to the animator’s <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-1">root element</a> changes:</p>
-   <ol>
-    <li data-md="">
-     <p>For each <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dictdef-scrolltimelineoptions">ScrollTimelineOptions</a></code> instance <var>options</var> in the animator’s <a data-link-type="dfn" href="#animator-timeline-options-list" id="ref-for-animator-timeline-options-list-4">animator timeline
-   options list</a> do the following steps:</p>
-     <ol>
-      <li data-md="">
-       <p>Let <var>timeline</var> be a <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#scrolltimeline">ScrollTimeline</a></code> created from <var>options</var>, adding the nearest non-visible
- overflow ancestor of the <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-2">root element</a> as the <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dom-scrolltimeline-scrollsource">scrollSource</a></code>.</p>
-      <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://wicg.github.io/scroll-animations/#current-time-algorithm">current time of the ScrollTimeline</a> <var>timeline</var> would have changed due to the
- change in scroll position, set the animator’s <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-8">animation requested flag</a> to <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-5">frame-requested</a>.</p>
-     </ol>
-   </ol>
-   <p class="issue" id="issue-9b16e52a"><a class="self-link" href="#issue-9b16e52a"></a> Give each animator instance a re-used set of AnimationTimelines instead of creating them
-       specifically here and when running animations.</p>
-   <p class="issue" id="issue-a9c8649c"><a class="self-link" href="#issue-a9c8649c"></a> Need to add a definition for 'nearest non-visible overflow ancestor' to make sure all mentions
-       stay in sync.</p>
-   <h2 class="heading settled" data-level="10" id="running-animators"><span class="secno">10. </span><span class="content">Running Animators</span><a class="self-link" href="#running-animators"></a></h2>
-   <p>When a user agent wants to produce a new animation frame, if for any <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-12">animator instance</a> the
-associated <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-9">animation requested flag</a> is <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-6">frame-requested</a> then the the user agent <em>must</em> <a data-link-type="dfn" href="#run-animators" id="ref-for-run-animators-1">run animators</a> for the current frame.</p>
-   <p class="note" role="note"><span>Note:</span> The user agent is not required to run animations on every frame. It is legal to defer
+     <li data-md="">
+      <p>Let <var>animatorCtor</var> be the <a data-link-type="dfn" href="#class-constructor" id="ref-for-class-constructor-2">class constructor</a> of <var>definition</var>.</p>
+     <li data-md="">
+      <p>Let <var>timelineList</var> be a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> with <var>timeline</var> added to it.</p>
+     <li data-md="">
+      <p>Let <var>animatorInstance</var> be the result of <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>animatorCtor</var>).</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a> throws an exception, set the result of looking up <var>animationId</var> in <var>animatorInstanceMap</var> in <var>animatorInstanceMap</var> to <b>null</b>, and abort the following
+steps.</p>
+     <li data-md="">
+      <p>Set the following on <var>animatorInstance</var> with:</p>
+      <ul>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-4">animator name</a> being <var>name</var></p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-2">animation requested flag</a> being <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-1">frame-current</a></p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animator-output-effect" id="ref-for-animator-output-effect-1">animator output effect</a> being <var>effect</var></p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="#animator-timelines-list" id="ref-for-animator-timelines-list-1">animator timelines list</a> being <var>timelineList</var></p>
+      </ul>
+     <li data-md="">
+      <p>Set the result of looking up <var>animationId</var> in <var>animatorInstanceMap</var> to <var>animatorInstance</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="7.2" id="running-animators"><span class="secno">7.2. </span><span class="content">Running Animators</span><a class="self-link" href="#running-animators"></a></h3>
+   <p>When a user agent wants to produce a new animation frame, if for any <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-6">animator instance</a> the
+associated <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-3">animation requested flag</a> is <a data-link-type="dfn" href="#frame-requested" id="ref-for-frame-requested-1">frame-requested</a> then the the user agent <em>must</em> <a data-link-type="dfn" href="#run-animators" id="ref-for-run-animators-1">run animators</a> for the current frame.</p>
+   <p class="note" role="note"><span>Note:</span> The user agent is not required to run animations on every visual frame. It is legal to defer
       generating an animation frame until a later frame. This allow the user agent to
       provide a different service level according to their policy.</p>
-   <p>When the user agent wants to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-animators">run animators</dfn> in a given <var>workletGlobalScope</var>, it <em>must</em> iterate over all pairs of animator name and root element as (<var>animatorName</var>, <var>rootElement</var>). For each such pair:</p>
-   <ol>
-    <li data-md="">
-     <p>Let the <var>definition</var> be the result of looking up <var>animatorName</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-6">animator name to animator definition map</a>.</p>
-     <p>If <var>definition</var> does not exist then abort the following steps.</p>
-    <li data-md="">
-     <p>Let <var>instance</var> be the result of looking up (<var>animatorName</var>, <var>rootElement</var>) in the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#-animator-name-root-element-to-instance-map" id="ref-for--animator-name-root-element-to-instance-map-2">(animator name, root element) to instance map</a>.</p>
-     <p>If <var>instance</var> does not exist then <a data-link-type="dfn" href="#create-a-new-animator-instance" id="ref-for-create-a-new-animator-instance-1">create a new animator instance</a> for <var>animatorName</var>, <var>rootElement</var>, and <var>workletGlobalScope</var>, and let <var>instance</var> be the result of that.</p>
-    <li data-md="">
-     <p>If <var>instance</var> still does not exist or <var>instance</var> is <b>null</b> then abort the following steps.</p>
-    <li data-md="">
-     <p>If the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-10">animation requested flag</a> for <var>instance</var> is <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-4">frame-current</a> or the proxies
-    belonging to <var>instance</var> will not be visible within the visual viewport of the current frame
-    the user agent <em>may</em> abort all the following steps.</p>
-     <p class="issue" id="issue-dc52329c"><a class="self-link" href="#issue-dc52329c"></a> Consider giving user agents permission to skip running animator instances to throttle
-    slow animators.</p>
-    <li data-md="">
-     <p>Let <var>animateFunction</var> be <var>definition</var>’s <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-2">animate function</a>.</p>
-    <li data-md="">
-     <p>Let <var>timelines</var> be an empty <code>sequence&lt;AnimationTimeline></code>.</p>
-    <li data-md="">
-     <p>For each <var>timelineOptions</var> in the <a data-link-type="dfn" href="#animator-timeline-options-list" id="ref-for-animator-timeline-options-list-5">animator timeline options list</a> of <var>definition</var>, do the
-   following:</p>
-     <ul>
-      <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>timelineOptions</var>) is <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/web-animations/#dictdef-documenttimelineoptions">DocumentTimelineOptions</a></code>, push a new <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/web-animations/#documenttimeline">DocumentTimeline</a></code> created using <var>timelineOptions</var> to the <var>timelines</var> list.</p>
-      <li data-md="">
-       <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>timelineOptions</var>) is <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dictdef-scrolltimelineoptions">ScrollTimelineOptions</a></code>, push a new <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#scrolltimeline">ScrollTimeline</a></code> created using <var>timelineOptions</var> to the <var>timelines</var> list, adding the nearest non-visible
-overflow ancestor of <var>rootElement</var> as the <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/scroll-animations/#dom-scrolltimeline-scrollsource">scrollSource</a></code>.</p>
-     </ul>
-    <li data-md="">
-     <p>Let <var>elementMap</var> be an <a data-link-type="dfn" href="#element-proxy-map" id="ref-for-element-proxy-map-2">element proxy map</a> of <var>instance</var>.</p>
-    <li data-md="">
-     <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#es-invoking-callback-functions">Invoke</a> <var>animateFunction</var> with arguments «<var>elementMap</var>, <var>timelines</var>»,
+   <div class="algorithm" data-algorithm="run-animators">
+    <p>When the user agent wants to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-animators">run animators</dfn> in a given <var>workletGlobalScope</var>, it <em>must</em> iterate over all animation id as <var>animationId</var>. For each item:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>instance</var> be the result of looking up <var>animationId</var> in the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animation-id-to-instance-map" id="ref-for-animation-id-to-instance-map-2">animation id to instance map</a>.</p>
+      <p>If <var>instance</var> does not exist then abort the following steps.</p>
+     <li data-md="">
+      <p>Let <var>animatorName</var> be <var>instance</var>’s <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-5">animator name</a></p>
+     <li data-md="">
+      <p>Let the <var>definition</var> be the result of looking up <var>animatorName</var> on the <var>workletGlobalScope</var>’s <a data-link-type="dfn" href="#animator-name-to-animator-definition-map" id="ref-for-animator-name-to-animator-definition-map-4">animator name to animator definition map</a>.</p>
+      <p>If <var>definition</var> does not exist then abort the following steps.</p>
+     <li data-md="">
+      <p>If the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-4">animation requested flag</a> for <var>instance</var> is <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-2">frame-current</a> or the effect
+   belonging to the <var>instance</var> will not be visible within the visual viewport of the current
+   frame the user agent <em>may</em> abort all the following steps.</p>
+      <p class="issue" id="issue-07876098"><a class="self-link" href="#issue-07876098"></a> Consider giving user agents permission to skip running animator instances to
+    throttle slow animators.</p>
+     <li data-md="">
+      <p>Let <var>animateFunction</var> be <var>definition</var>’s <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-2">animate function</a>.</p>
+     <li data-md="">
+      <p>Let <var>timelines</var> be animator timelines list of <var>instance</var>.</p>
+     <li data-md="">
+      <p>Let <var>effect</var> be an <a data-link-type="dfn">animator</a> of <var>instance</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#es-invoking-callback-functions">Invoke</a> <var>animateFunction</var> with arguments «<var>timelines</var>, <var>effect</var>»,
     and with <var>instance</var> as the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>.</p>
-   </ol>
-   <p class="note" role="note"><span>Note:</span> Although inefficient, it is legal for the user agent to <a data-link-type="dfn" href="#run-animators" id="ref-for-run-animators-2">run animators</a> multiple times
-in the same frame.</p>
-   <h2 class="heading settled" data-level="11" id="closing-animator"><span class="secno">11. </span><span class="content">Closing an Animator</span><a class="self-link" href="#closing-animator"></a></h2>
-   <p class="issue" id="issue-d4d8f39c"><a class="self-link" href="#issue-d4d8f39c"></a> Todo: Define when we may get rid of the animator.</p>
-   <h2 class="heading settled" data-level="12" id="css-animator-notation"><span class="secno">12. </span><span class="content">CSS Animator Notation</span><a class="self-link" href="#css-animator-notation"></a></h2>
-   <p>Two CSS properties <a class="property" data-link-type="propdesc" href="#propdef-animator-root" id="ref-for-propdef-animator-root-2">animator-root</a> and <a class="property" data-link-type="propdesc" href="#propdef-animator" id="ref-for-propdef-animator-2">animator</a> may be used to assign an HTML elements to an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-13">animator instance</a> either as a root element or a child element.</p>
-   <table class="def propdef" data-link-for-hint="animator-root">
-    <tbody>
-     <tr>
-      <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-animator-root">animator-root</dfn>
-     <tr class="value">
-      <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-3">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-2">animator slot</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a> <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-4">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-3">animator slot</a>
-     <tr>
-      <th>Initial:
-      <td>none
-     <tr>
-      <th>Applies to:
-      <td><a href="https://drafts.csswg.org/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
-     <tr>
-      <th>Inherited:
-      <td>no
-     <tr>
-      <th>Percentages:
-      <td>N/A
-     <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
-      <th>Computed value:
-      <td>as specified
-     <tr>
-      <th>Canonical order:
-      <td>per grammar
-     <tr>
-      <th>Animatable:
-      <td>no
-   </table>
-   <dl>
-    <dt><dfn class="css" data-dfn-for="animator-root" data-dfn-type="value" data-export="" id="valdef-animator-root-none">none<a class="self-link" href="#valdef-animator-root-none"></a></dfn> 
-    <dd> There will be no <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-14">animator instance</a> that has this element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-3">root element</a>. 
-    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-5">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-4">animator slot</a> 
-    <dd>
-      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-6">animator name</a> specified in the list, the following applies for each animation frame: 
-     <ul>
-      <li data-md="">
-       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-3">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-7">animator name</a>, the inclusion
-of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-8">animator name</a> as a value has no effect.</p>
-      <li data-md="">
-       <p>Otherwise, an <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-15">animator instance</a> with this element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-4">root element</a> will exist and will have its <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-3">animate function</a> called (with respect to the rules
-laid out in <a href="#running-animators">§10 Running Animators</a>) with an <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-6">element proxy</a> for this element passed as
-one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-7">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-5">animator slot</a>.</p>
-     </ul>
-     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-9">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-10">animator name</a> is processed.</p>
-   </dl>
-   <table class="def propdef" data-link-for-hint="animator">
-    <tbody>
-     <tr>
-      <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-animator">animator</dfn>
-     <tr class="value">
-      <th>Value:
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> [<a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-11">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-6">animator slot</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a> <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-12">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-7">animator slot</a>
-     <tr>
-      <th>Initial:
-      <td>none
-     <tr>
-      <th>Applies to:
-      <td><a href="https://drafts.csswg.org/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
-     <tr>
-      <th>Inherited:
-      <td>no
-     <tr>
-      <th>Percentages:
-      <td>N/A
-     <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
-      <th>Computed value:
-      <td>as specified
-     <tr>
-      <th>Canonical order:
-      <td>per grammar
-     <tr>
-      <th>Animatable:
-      <td>no
-   </table>
-   <dl>
-    <dt><dfn class="css" data-dfn-for="animator" data-dfn-type="value" data-export="" id="valdef-animator-none">none<a class="self-link" href="#valdef-animator-none"></a></dfn> 
-    <dd> This element will not be passed into any <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-4">animate function</a> as one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-8">element proxies</a>. 
-    <dt><a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-13">animator name</a> <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-8">animator slot</a> 
-    <dd>
-      For each <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-14">animator name</a> specified in the list, the following applies for each animation frame: 
-     <ul>
-      <li data-md="">
-       <p>If there is no <a data-link-type="dfn" href="#animator-definition" id="ref-for-animator-definition-4">animator definition</a> registered with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-15">animator name</a>, the inclusion
-of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-16">animator name</a> as a value has no effect.</p>
-      <li data-md="">
-       <p>Otherwise, an <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-9">element proxy</a> for this element will be passed into the <a data-link-type="dfn" href="#animate-function" id="ref-for-animate-function-5">animate function</a> of the closest ancestor <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-16">animator instance</a> with the given <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-17">animator name</a> as one of the <a data-link-type="dfn" href="#element-proxy" id="ref-for-element-proxy-10">element proxies</a> for the given <a data-link-type="dfn" href="#animator-slot" id="ref-for-animator-slot-9">animator slot</a>. If no
-such <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-17">animator instance</a> exists, one is created with the document root element as its <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-5">root element</a>.</p>
-     </ul>
-     <p>If the same <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-18">animator name</a> occurs multiple times in the list, only the first occurrence of that <a data-link-type="dfn" href="#animator-name" id="ref-for-animator-name-19">animator name</a> is processed.</p>
-   </dl>
-   <h2 class="heading settled" data-level="13" id="effect-stack"><span class="secno">13. </span><span class="content">Effect Stack</span><a class="self-link" href="#effect-stack"></a></h2>
-   <p class="issue" id="issue-b3b90f2d"><a class="self-link" href="#issue-b3b90f2d"></a> Todo: the animators output style values have the highest order in animation stack effect and
-their composite operation is "replace" which is going to allow them to run independent on other
-animations and in a different thread. Supporting other composite operation is not in scope at this
-point.</p>
-   <h2 class="heading settled" data-level="14" id="security-considerations"><span class="secno">14. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
+    </ol>
+   </div>
+    Note: Although inefficient, it is legal for the user agent to <a data-link-type="dfn" href="#run-animators" id="ref-for-run-animators-2">run animators</a> multiple times
+in the same frame. 
+   <h3 class="heading settled" data-level="7.3" id="removing-animator"><span class="secno">7.3. </span><span class="content">Removing an Animator</span><a class="self-link" href="#removing-animator"></a></h3>
+   <p class="issue" id="issue-216cac5b"><a class="self-link" href="#issue-216cac5b"></a> Define when we may get rid of the animator.</p>
+   <h3 class="heading settled" data-level="7.4" id="requesting-animation-frames"><span class="secno">7.4. </span><span class="content">Requesting Animation Frames</span><a class="self-link" href="#requesting-animation-frames"></a></h3>
+   <p>Each <a data-link-type="dfn" href="#animator-instance" id="ref-for-animator-instance-7">animator instance</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="animation-requested-flag">animation requested flag</dfn>. It must be
+either <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-requested">frame-requested</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frame-current">frame-current</dfn>. It is initially set to <a data-link-type="dfn">frame-
+current</a>. Various events, for example changes in of the animator’s <a data-link-type="dfn" href="#animator-timelines-list" id="ref-for-animator-timelines-list-2">animator timelines
+list</a> currentTime can cause the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-5">animation requested flag</a> to be set to <a data-link-type="dfn">frame-
+requested</a>.</p>
+   <p><a href="#running-animators">§7.2 Running Animators</a> resets the <a data-link-type="dfn" href="#animation-requested-flag" id="ref-for-animation-requested-flag-6">animation requested flag</a> on animators to <a data-link-type="dfn" href="#frame-current" id="ref-for-frame-current-3">frame-current</a>.</p>
+   <h2 class="heading settled" data-level="8" id="integration-web-animation"><span class="secno">8. </span><span class="content">Integration With Web Animations</span><a class="self-link" href="#integration-web-animation"></a></h2>
+   <h3 class="heading settled" data-level="8.1" id="creating-worklet-animation"><span class="secno">8.1. </span><span class="content">Creating an Worklet Animation</span><a class="self-link" href="#creating-worklet-animation"></a></h3>
+    TODO: 
+   <ul>
+    <li data-md="">
+     <p>add IDL for worklet animation</p>
+    <li data-md="">
+     <p>describe how constructor handles single or sequence of effects</p>
+    <li data-md="">
+     <p>define new semantics for reverse/finish/playbackRate.</p>
+    <li data-md="">
+     <p>define what happens when timeline or effect is modified document scope</p>
+    <li data-md="">
+     <p>define what it means when localTime is read on this instance (i.e., we get last value synced
+from worklet scope)</p>
+   </ul>
+   <p class="issue" id="issue-c2cb2c27"><a class="self-link" href="#issue-c2cb2c27"></a> describe how constructor handles single or sequence of effects
+Issue(63): define new semantics for reverse/finish/playbackRate</p>
+   <h3 class="heading settled" data-level="8.2" id="timeline-attachment"><span class="secno">8.2. </span><span class="content">Timeline Attachment</span><a class="self-link" href="#timeline-attachment"></a></h3>
+   <p>TODO</p>
+   <p class="issue" id="issue-8cedaea7"><a class="self-link" href="#issue-8cedaea7"></a> Define semantics of attachment and detachment</p>
+   <h3 class="heading settled" data-level="8.3" id="worklet-group-effect"><span class="secno">8.3. </span><span class="content">WorkletGroupEffect</span><a class="self-link" href="#worklet-group-effect"></a></h3>
+    TODO: 
+   <ul>
+    <li data-md="">
+     <p>Add idl for worklet group effect</p>
+    <li data-md="">
+     <p>define the children start time schedule for the group effect. [Issue](https://github.com/w3c/web-animations/issues/191)</p>
+   </ul>
+   <h3 class="heading settled" data-level="8.4" id="timing-model"><span class="secno">8.4. </span><span class="content">WorkletAnimation timing model</span><a class="self-link" href="#timing-model"></a></h3>
+    TODO: 
+   <ul>
+    <li data-md="">
+     <p>Describe the relation of WorkletAnimation.currentTime with its timeline time</p>
+    <li data-md="">
+     <p>Describe the relation of WorkletAnimation.effect.getComputedTiming().localTime with the local time
+set in the worklet scope.</p>
+   </ul>
+   <h3 class="heading settled" data-level="8.5" id="effect-stack"><span class="secno">8.5. </span><span class="content">Effect Stack</span><a class="self-link" href="#effect-stack"></a></h3>
+   <p class="issue" id="issue-8d2c2dd1"><a class="self-link" href="#issue-8d2c2dd1"></a> Worklet animations will have a special animation class that  ranks them with the highest
+order in animation stack effect. also their composite operation is "replace" which is going to
+allow them to run in parallel to other web animations in the system. Supporting other
+composite operation is not in scope at this point.</p>
+   <h2 class="heading settled" data-level="9" id="security-considerations"><span class="secno">9. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
    <p class="issue" id="issue-de770110"><a class="self-link" href="#issue-de770110"></a> Need to decide what security considerations there are for this spec.</p>
-   <h2 class="heading settled" data-level="15" id="privacy-considerations"><span class="secno">15. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
+   <h2 class="heading settled" data-level="10" id="privacy-considerations"><span class="secno">10. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
    <p class="issue" id="issue-19f9ed9b"><a class="self-link" href="#issue-19f9ed9b"></a> Need to decide what privacy considerations there are for this spec.</p>
-   <h2 class="heading settled" data-level="16" id="examples"><span class="secno">16. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
-   <h3 class="heading settled" data-level="16.1" id="example-1"><span class="secno">16.1. </span><span class="content">Example 1: A fade-in animation with spring timing.</span><a class="self-link" href="#example-1"></a></h3>
-<pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">.</span><span class="nc">myFadein</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="s1">'spring'</span> <span class="s1">'fadein'</span><span class="p">;</span>
-<span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
-
-
-<span class="p">&lt;</span><span class="nt">section</span> <span class="na">class</span><span class="o">=</span><span class="s">'myFadein'</span><span class="p">>&lt;/</span><span class="nt">section</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">section</span> <span class="na">class</span><span class="o">=</span><span class="s">'myFadein'</span> <span class="na">style</span><span class="o">=</span><span class="s">"--spring-k: 25;"</span><span class="p">>&lt;/</span><span class="nt">section</span><span class="p">></span>
-
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-document<span class="p">.</span>animationWorklet<span class="p">.</span><span class="kr">import</span><span class="p">(</span><span class="s1">'spring-timing.js'</span><span class="p">);</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
-</pre>
-<pre class="lang-javascript highlight"><span class="c1">// Inside AnimationWorkletGlobalScope</span>
-<span class="c1"></span>registerAnimator<span class="p">(</span><span class="s1">'spring'</span><span class="p">,</span> <span class="kr">class</span> <span class="p">{</span>
-
-    <span class="kr">static</span> elements <span class="o">=</span> <span class="p">[</span>
-        <span class="p">{</span>name<span class="o">:</span> <span class="s1">'fadein'</span><span class="p">,</span> inputProperties<span class="o">:</span>  <span class="p">[</span><span class="s1">'--spring-k'</span><span class="p">],</span> outputProperties <span class="o">=</span>  <span class="p">[</span><span class="s1">'opacity'</span><span class="p">]}];</span>
-    <span class="kr">static</span> timelines <span class="o">=</span> <span class="p">[</span><span class="s1">'document'</span><span class="p">];</span>
-
-    animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
-        <span class="k">this</span><span class="p">.</span>startTime_ <span class="o">=</span> <span class="k">this</span><span class="p">.</span>startTime_ <span class="o">||</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime<span class="p">;</span>
-        <span class="kr">const</span> deltaT <span class="o">=</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime <span class="o">-</span> <span class="k">this</span><span class="p">.</span>startTime_<span class="p">;</span>
-        elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'fadein'</span><span class="p">).</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
-          <span class="c1">// read a custom css property.</span>
-<span class="c1"></span>          <span class="kr">const</span> k <span class="o">=</span> elem<span class="p">.</span>inputStyleMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'--spring-k'</span><span class="p">)</span> <span class="o">||</span> <span class="mi">1</span><span class="p">;</span>
-          <span class="c1">// compute progress using a fancy spring timing function.</span>
-<span class="c1"></span>          <span class="kr">const</span> effectiveValue <span class="o">=</span> <span class="mi">1</span> <span class="o">*</span> springTiming<span class="p">(</span>deltaT<span class="p">,</span> k<span class="p">);</span>
-          <span class="c1">// update opacity accordingly.</span>
-<span class="c1"></span>          elem<span class="p">.</span>ouputStyleMap<span class="p">.</span>opacity <span class="o">=</span> effectiveValue<span class="p">;</span>
-        <span class="p">});</span>
-    <span class="p">}</span>
-
-    springTiming<span class="p">(</span>deltaT<span class="p">,</span> k<span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// simulate the spring effect and return a progress value between [-1, 1];</span>
-<span class="c1"></span>    <span class="p">}</span>
-<span class="p">});</span>
-</pre>
-   <h3 class="heading settled" data-level="16.2" id="example-2"><span class="secno">16.2. </span><span class="content">Example 2: Twitter header.</span><a class="self-link" href="#example-2"></a></h3>
-<pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">#</span><span class="nn">scroller</span> <span class="p">{</span>
-  <span class="n">animator-root</span><span class="p">:</span> <span class="n">twitter-header</span><span class="p">;</span>
-<span class="p">}</span>
-<span class="p">.</span><span class="nc">avatar</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="n">twitter-header</span> <span class="n">avatar</span><span class="p">;</span>
-<span class="p">}</span>
-<span class="p">.</span><span class="nc">bar</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="n">twitter-header</span> <span class="n">bar</span><span class="p">;</span>
-<span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
-
-<span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"scroller"</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">section</span> <span class="na">class</span><span class="o">=</span><span class="s">"bar"</span><span class="p">>&lt;/</span><span class="nt">section</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">header</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">picture</span> <span class="na">class</span><span class="o">=</span><span class="s">"avatar"</span><span class="p">></span>
-      <span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"avatar.jpg"</span><span class="p">></span>
-    <span class="p">&lt;/</span><span class="nt">picture</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">section</span><span class="p">></span>
-      <span class="p">&lt;</span><span class="nt">button</span><span class="p">></span>Friends<span class="p">&lt;/</span><span class="nt">button</span><span class="p">></span>
-      <span class="p">&lt;</span><span class="nt">button</span><span class="p">></span>Edit Profile<span class="p">&lt;/</span><span class="nt">button</span><span class="p">></span>
-    <span class="p">&lt;/</span><span class="nt">section</span><span class="p">></span>
-  <span class="p">&lt;/</span><span class="nt">header</span><span class="p">></span>
+   <h2 class="heading settled" data-level="11" id="examples"><span class="secno">11. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
+   <h3 class="heading settled" data-level="11.1" id="example-1"><span class="secno">11.1. </span><span class="content">Example 1: Hidey Bar.</span><a class="self-link" href="#example-1"></a></h3>
+    An example of header effect where a header is moved with scroll and as soon as finger is lifted it animates fully to close or open position depending on its current position. 
+<pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'scrollingContainer'</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'header'</span><span class="p">></span>Some header<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span><span class="p">></span>content<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
 <span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
 
 <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-document<span class="p">.</span>animationWorklet<span class="p">.</span><span class="kr">import</span><span class="p">(</span><span class="s1">'tweeter-header.js'</span><span class="p">);</span>
+animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'hidey-bar-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="p">=></span> <span class="p">{</span>
+  <span class="kr">const</span> scrollTimeline <span class="o">=</span> <span class="k">new</span> ScrollTimeline<span class="p">(</span>$scrollingContainer<span class="p">,</span> <span class="p">{</span>timeRange<span class="o">:</span> <span class="mi">100</span><span class="p">});</span>
+
+  <span class="kd">var</span> workletAnim <span class="o">=</span> <span class="k">new</span> WorkletAnimation<span class="p">(</span><span class="s1">'hidey-bar'</span><span class="p">,</span>
+    <span class="k">new</span> KeyFrameEffect<span class="p">(</span>$header<span class="p">,</span>
+                       <span class="p">[{</span>transform<span class="o">:</span> <span class="s1">'translateX(100px)'</span><span class="p">},</span> <span class="p">{</span>transform<span class="o">:</span> <span class="s1">'translateX(0px)'</span><span class="p">}],</span>
+                       <span class="p">{</span>duration<span class="o">:</span> <span class="mi">100</span><span class="p">,</span> iterations<span class="o">:</span> <span class="mi">1</span><span class="p">,</span> fill<span class="o">:</span> <span class="s1">'both'</span> <span class="p">})</span>
+    <span class="p">[</span>scrollTimeline<span class="p">,</span> document<span class="p">.</span>timeline<span class="p">],</span>
+  <span class="p">);</span>
+<span class="p">});</span>
+
+
+workletAnim<span class="p">.</span>timeline <span class="o">==</span> scrollTimeline<span class="p">;</span> <span class="c1">// true, timeline returns the primary timeline</span>
+<span class="c1"></span>
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
-<pre class="lang-javascript highlight"><span class="c1">// Inside AnimationWorkletGlobalScope.</span>
+<pre class="lang-javascript highlight"><span class="c1">// Inside AnimationWorkletGlobalScope</span>
+<span class="c1"></span>
+registerAnimator<span class="p">(</span><span class="s1">'hidey-bar'</span><span class="p">,</span> <span class="kr">class</span> <span class="p">{</span>
+  animate<span class="p">(</span>timelines<span class="p">,</span> effects<span class="p">)</span> <span class="p">{</span>
+    <span class="kr">const</span> scroll <span class="o">=</span> timeline<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime<span class="p">;</span>  <span class="c1">// [0, 100]</span>
+<span class="c1"></span>    <span class="kr">const</span> time <span class="o">=</span> timelines<span class="p">[</span><span class="mi">1</span><span class="p">].</span>currentTime<span class="p">;</span>
+
+    activelyScrolling <span class="o">=</span> timeline<span class="p">[</span><span class="mi">0</span><span class="p">].</span>phase <span class="o">==</span> <span class="s1">'active'</span><span class="p">;</span>
+
+    <span class="kd">let</span> localTime<span class="p">;</span>
+    <span class="k">if</span> <span class="p">(</span>activelyScrolling<span class="p">)</span> <span class="p">{</span>
+      <span class="k">this</span><span class="p">.</span>startTime_ <span class="o">=</span> <span class="kc">undefined</span><span class="p">;</span>
+      localTime <span class="o">=</span> scroll<span class="p">;</span>
+    <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
+      <span class="k">this</span><span class="p">.</span>startTime_ <span class="o">=</span> <span class="k">this</span><span class="p">.</span>startTime_ <span class="o">||</span> time<span class="p">;</span>
+      <span class="c1">// Decide on close/open direction depending on how far we have scrolled the header</span>
+<span class="c1"></span>      <span class="c1">// This can even do more sophisticated animation curve by computing the scroll velocity and</span>
+<span class="c1"></span>      <span class="c1">// using it.</span>
+<span class="c1"></span>      <span class="k">this</span><span class="p">.</span>direction_ <span class="o">=</span> scroll <span class="o">>=</span> <span class="mi">50</span> <span class="o">?</span> <span class="o">+</span><span class="mi">1</span> <span class="o">:</span> <span class="o">-</span><span class="mi">1</span><span class="p">;</span>
+      localTime <span class="o">=</span> <span class="k">this</span><span class="p">.</span>direction_ <span class="o">*</span> <span class="p">(</span>time <span class="o">-</span> <span class="k">this</span><span class="p">.</span>startTime_<span class="p">);</span>
+    <span class="p">}</span>
+
+    <span class="c1">// Drive the output effects by setting its local time.</span>
+<span class="c1"></span>    effect<span class="p">.</span>localTime <span class="o">=</span> localTime<span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">});</span>
+</pre>
+   <p class="issue" id="issue-e1ad2274"><a class="self-link" href="#issue-e1ad2274"></a> This example uses a hypothetical <a class="property" data-link-type="propdesc">phase</a> property on timeline as a way to detect when user
+is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
+fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
+the last few frames.</p>
+   <h3 class="heading settled" data-level="11.2" id="example-2"><span class="secno">11.2. </span><span class="content">Example 2: Twitter header.</span><a class="self-link" href="#example-2"></a></h3>
+    An example of twitter profile header effect where two elements (avatar, and header) are updated in
+sync with scroll offset. 
+<pre class="lang-markup highlight">// In document scope
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'scrollingContainer'</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'header'</span> <span class="na">style</span><span class="o">=</span><span class="s">'height: 150px'</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">'avatar'</span><span class="p">>&lt;</span><span class="nt">img</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+animationWorklet<span class="p">.</span>addModule<span class="p">(</span><span class="s1">'twitter-header-animator.js'</span><span class="p">).</span>then<span class="p">(</span> _ <span class="p">=></span> <span class="p">{</span>
+  <span class="kr">const</span> workletAnim <span class="o">=</span> <span class="k">new</span> WorkletAnimation<span class="p">(</span><span class="s1">'twitter-header'</span><span class="p">,</span>
+    <span class="p">[</span><span class="k">new</span> KeyFrameEffect<span class="p">(</span>$avatar<span class="p">,</span>  <span class="cm">/* scales down as we scroll up */</span>
+                        <span class="p">[{</span>transform<span class="o">:</span> <span class="s1">'scale(1)'</span><span class="p">},</span> <span class="p">{</span>transform<span class="o">:</span> <span class="s1">'scale(0.5)'</span><span class="p">}],</span>
+                        <span class="p">{</span>duration<span class="o">:</span> <span class="mi">1</span><span class="p">,</span> iterations<span class="o">:</span> <span class="mi">1</span><span class="p">}),</span>
+     <span class="k">new</span> KeyFrameEffect<span class="p">(</span>$header<span class="p">,</span> <span class="cm">/* loses transparency as we scroll up */</span>
+                        <span class="p">{</span>opacity<span class="o">:</span> <span class="mi">0</span><span class="p">,</span> opacity<span class="o">:</span> <span class="mf">0.8</span><span class="p">},</span>
+                        <span class="p">{</span>duration<span class="o">:</span> <span class="mi">1</span><span class="p">,</span> iterations<span class="o">:</span> <span class="mi">1</span><span class="p">})]</span> <span class="p">,</span>
+     <span class="p">[</span><span class="k">new</span> ScrollTimeline<span class="p">(</span>$scrollingContainer<span class="p">,</span> <span class="p">{</span>timeRange<span class="o">:</span> <span class="mi">1</span><span class="p">,</span> startScrollOffset<span class="o">:</span> <span class="mi">0</span><span class="p">,</span> endScrollOffset<span class="o">:</span> $header<span class="p">.</span>clientHeight<span class="p">})],</span>
+  <span class="p">);</span>
+
+  <span class="c1">// Same animation instance is accessible via different animation targets</span>
+<span class="c1"></span>  workletAnim <span class="o">==</span> $avatarEl<span class="p">.</span>getAnimations<span class="p">()[</span><span class="mi">0</span><span class="p">]</span> <span class="o">==</span> $headerEl<span class="p">.</span>getAnimations<span class="p">()[</span><span class="mi">0</span><span class="p">];</span>
+
+<span class="p">});</span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+</pre>
+<pre class="lang-javascript highlight"><span class="c1">// Ins AnimationWorkletGlobalScope.</span>
 <span class="c1"></span>registerAnimator<span class="p">(</span><span class="s1">'twitter-header'</span><span class="p">,</span> <span class="kr">class</span> <span class="p">{</span>
-
-  <span class="kr">static</span> elements <span class="o">=</span>  <span class="p">[</span>
-    <span class="p">{</span>name<span class="o">:</span> <span class="s1">'avatar'</span><span class="p">,</span> inputProperties<span class="o">:</span> <span class="p">[],</span> outputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'transform'</span><span class="p">]},</span>
-    <span class="p">{</span>name<span class="o">:</span> <span class="s1">'bar'</span><span class="p">,</span> inputProperties<span class="o">:</span> <span class="p">[],</span> outputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'opacity'</span><span class="p">]}</span>
-  <span class="p">];</span>
-
-  <span class="c1">// maps scroll offset [0, 140px] -> time values [0, 1]</span>
-<span class="c1"></span>  <span class="kr">static</span> timelines <span class="o">=</span> <span class="p">[</span> <span class="p">{</span> type<span class="o">:</span> <span class="s1">'scroll'</span><span class="p">,</span> options<span class="o">:</span> <span class="p">{</span>
-      orientation<span class="o">:</span> <span class="s1">'vertical'</span><span class="p">,</span>
-      endScrollOffset<span class="o">:</span> <span class="s1">'140px'</span><span class="p">,</span>
-      timeRange<span class="o">:</span> <span class="mi">1</span>
-    <span class="p">}},</span>
-  <span class="p">];</span>
-
-
-  animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
-    <span class="kd">var</span> progress <span class="o">=</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime<span class="p">;</span>
-
-    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'avatar'</span><span class="p">).</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
-      elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'transform'</span><span class="p">,</span> <span class="k">new</span> CSSTransformValue<span class="p">([</span>
-          <span class="k">new</span> CSSTranslation<span class="p">(</span><span class="k">new</span> CSSSimpleLength<span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="s1">'px'</span><span class="p">),</span>
-                             <span class="k">new</span> CSSSimpleLength<span class="p">(</span>tween<span class="p">(</span><span class="mi">140</span><span class="p">,</span> <span class="mi">45</span><span class="p">)(</span>progress<span class="p">),</span> <span class="s1">'px'</span><span class="p">)),</span>
-          <span class="k">new</span> CSSScale<span class="p">(</span>tween<span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">)(</span>progress<span class="p">),</span> tween<span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">)(</span>progress<span class="p">))</span>
-          <span class="p">]));</span>
-    <span class="p">});</span>
-    elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'bar'</span><span class="p">).</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
-      elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'opacity'</span><span class="p">,</span> progress<span class="p">);</span>
-    <span class="p">});</span>
+  constructor<span class="p">(</span>options<span class="p">)</span> <span class="p">{</span>
+    <span class="k">this</span><span class="p">.</span>timing_ <span class="o">=</span> <span class="k">new</span> CubicBezier<span class="p">(</span><span class="s1">'ease-out'</span><span class="p">);</span>
   <span class="p">}</span>
 
-  tween<span class="p">(</span>begin<span class="p">,</span> end<span class="p">)</span> <span class="p">{</span>
-    <span class="k">return</span> <span class="kd">function</span> lerp<span class="p">(</span>progress<span class="p">)</span> <span class="p">{</span>
-        <span class="k">return</span> begin <span class="o">+</span> <span class="p">(</span>end <span class="o">-</span> begin<span class="p">)</span> <span class="o">*</span> progress<span class="p">;</span>
-    <span class="p">}</span>
+  clamp<span class="p">(</span>value<span class="p">,</span> min<span class="p">,</span> max<span class="p">)</span> <span class="p">{</span>
+    <span class="k">return</span> Math<span class="p">.</span>min<span class="p">(</span>Math<span class="p">.</span>max<span class="p">(</span>value<span class="p">,</span> min<span class="p">),</span> max<span class="p">);</span>
+  <span class="p">}</span>
+
+  animate<span class="p">(</span>timelines<span class="p">,</span> effect<span class="p">)</span> <span class="p">{</span>
+    <span class="kr">const</span> scroll <span class="o">=</span> timeline<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime<span class="p">;</span>  <span class="c1">// scroll is in [0, 1] range</span>
+<span class="c1"></span>
+    <span class="c1">// Drive the output group effect by setting its children local times individually.</span>
+<span class="c1"></span>    effects<span class="p">.</span>children<span class="p">[</span><span class="mi">0</span><span class="p">].</span>localTime <span class="o">=</span> scroll<span class="p">;</span>
+    effects<span class="p">.</span>children<span class="p">[</span><span class="mi">1</span><span class="p">].</span>localTime <span class="o">=</span> <span class="k">this</span><span class="p">.</span>timing_<span class="p">(</span>clamp<span class="p">(</span>scroll<span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">));</span>
   <span class="p">}</span>
 <span class="p">});</span>
 </pre>
-   <h3 class="heading settled" data-level="16.3" id="example-3"><span class="secno">16.3. </span><span class="content">Example 3: Parallax backgrounds.</span><a class="self-link" href="#example-3"></a></h3>
-<pre class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-<span class="p">#</span><span class="nn">scroller</span> <span class="p">{</span>
-  <span class="n">animator-root</span><span class="p">:</span> <span class="s1">'parallax'</span><span class="p">;</span>
-<span class="p">}</span>
-<span class="p">.</span><span class="nc">background</span> <span class="p">{</span>
-  <span class="n">animator</span><span class="p">:</span> <span class="s1">'parallax'</span> <span class="s1">'background'</span><span class="p">;</span>
-<span class="p">}</span>
-
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
-
-<span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"scroller"</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"background"</span> <span class="na">style</span><span class="o">=</span><span class="s">"--parallax-rate: 0.6"</span> <span class="p">></span>
-    <span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"background"</span> <span class="na">style</span><span class="o">=</span><span class="s">"--parallax-rate: 0.3"</span> <span class="p">></span>
-    <span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-
-    overflowing content!
-<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
-
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-document<span class="p">.</span>animationWorklet<span class="p">.</span><span class="kr">import</span><span class="p">(</span><span class="s1">'parallax.js'</span><span class="p">);</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
-</pre>
-<pre class="lang-javascript highlight"><span class="c1">// Inside AnimationWorkletGlobalScope</span>
-<span class="c1"></span>registerAnimation<span class="p">(</span><span class="s1">'parallax'</span><span class="p">,</span> <span class="kr">class</span> <span class="p">{</span>
-
-    <span class="kr">static</span> elements <span class="o">=</span>  <span class="p">[</span>
-        <span class="p">{</span> name<span class="o">:</span> <span class="s1">'background'</span><span class="p">,</span> inputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'--parallax-rate'</span><span class="p">],</span> outputProperties<span class="o">:</span> <span class="p">[</span><span class="s1">'transform'</span><span class="p">]}</span>
-    <span class="p">];</span>
-
-    <span class="kr">static</span> timelines <span class="o">=</span> <span class="p">[{</span> type<span class="o">:</span> <span class="s1">'scroll'</span><span class="p">,</span> options<span class="o">:</span> <span class="p">{</span> orientation<span class="o">:</span> <span class="s1">'vertical'</span><span class="p">}</span> <span class="p">}];</span>
-
-    <span class="c1">// This can be passed in as an input but we should consider exposing this in ScrollTimeline</span>
-<span class="c1"></span>    <span class="kr">static</span> SCROLL_SIZE <span class="o">=</span> <span class="mi">1000</span><span class="p">;</span>
-
-    animate<span class="p">(</span>elementMap<span class="p">,</span> timelines<span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// read root scroller vertical scroll offset.</span>
-<span class="c1"></span>        <span class="kr">const</span> scrollTop <span class="o">=</span> timelines<span class="p">[</span><span class="mi">0</span><span class="p">].</span>currentTime <span class="o">*</span> SCROLL_SIZE<span class="p">;</span>
-        <span class="c1">// update parallax transform</span>
-<span class="c1"></span>        elementMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'background'</span><span class="p">).</span>forEach<span class="p">(</span>elem <span class="p">=></span> <span class="p">{</span>
-           <span class="kr">const</span> rate <span class="o">=</span> elem<span class="p">.</span>inputStyleMap<span class="p">.</span>get<span class="p">(</span><span class="s1">'--parallax-rate'</span><span class="p">)</span> <span class="o">||</span> <span class="mf">0.2</span><span class="p">;</span>
-           elem<span class="p">.</span>outputStyleMap<span class="p">.</span>set<span class="p">(</span><span class="s1">'transform'</span><span class="p">,</span> <span class="k">new</span> CSSTransformValue<span class="p">([</span>
-            <span class="k">new</span> CSSTranslation<span class="p">(</span><span class="k">new</span> CSSSimpleLength<span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="s1">'px'</span><span class="p">),</span> <span class="k">new</span> CSSSimpleLength<span class="p">(</span>rate <span class="o">*</span> scrollTop<span class="p">,</span> <span class="s1">'px'</span><span class="p">))]));</span>
-        <span class="p">});</span>
-    <span class="p">}</span>
-<span class="p">});</span>
-</pre>
+   <h3 class="heading settled" data-level="11.3" id="example-3"><span class="secno">11.3. </span><span class="content">Example 3: Parallax backgrounds.</span><a class="self-link" href="#example-3"></a></h3>
+   <p>TODO</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2358,74 +2049,36 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-animationworklet-addmodule">addModule(moduleURL)</a><span>, in §4</span>
    <li><a href="#animate-function">animate function</a><span>, in §5</span>
-   <li><a href="#animation-requested-flag">animation requested flag</a><span>, in §9</span>
+   <li><a href="#animation-id-to-instance-map">animation id to instance map</a><span>, in §7.1</span>
+   <li><a href="#animation-requested-flag">animation requested flag</a><span>, in §7.4</span>
    <li><a href="#animation-worklet">Animation Worklet</a><span>, in §4</span>
    <li><a href="#dom-window-animationworklet">animationWorklet</a><span>, in §4</span>
-   <li><a href="#animationworklet">AnimationWorklet</a><span>, in §4</span>
    <li><a href="#animationworkletglobalscope">AnimationWorkletGlobalScope</a><span>, in §4</span>
-   <li><a href="#propdef-animator">animator</a><span>, in §12</span>
    <li><a href="#animator-definition">animator definition</a><span>, in §5</span>
-   <li><a href="#animator-input-property-list">animator input property list</a><span>, in §5</span>
    <li><a href="#animator-instance">animator instance</a><span>, in §5</span>
    <li><a href="#animator-name">animator name</a><span>, in §5</span>
-   <li><a href="#-animator-name-root-element-to-instance-map">(animator name, root element) to instance map</a><span>, in §7</span>
    <li><a href="#animator-name-to-animator-definition-map">animator name to animator definition map</a><span>, in §6</span>
-   <li><a href="#animator-output-property-list">animator output property list</a><span>, in §5</span>
-   <li><a href="#propdef-animator-root">animator-root</a><span>, in §12</span>
-   <li><a href="#animator-slot">animator slot</a><span>, in §5</span>
-   <li><a href="#animator-slot-list">animator slot list</a><span>, in §5</span>
-   <li><a href="#animator-timeline-options-list">animator timeline options list</a><span>, in §5</span>
+   <li><a href="#animator-output-effect">animator output effect</a><span>, in §5</span>
+   <li><a href="#animator-timelines-list">animator timelines list</a><span>, in §5</span>
    <li><a href="#class-constructor">class constructor</a><span>, in §5</span>
-   <li><a href="#create-an-element-proxy">create an element proxy</a><span>, in §8</span>
-   <li><a href="#create-a-new-animator-instance">create a new animator instance</a><span>, in §7</span>
-   <li><a href="#elementproxy">ElementProxy</a><span>, in §8</span>
-   <li><a href="#element-proxy">element proxy</a><span>, in §5</span>
-   <li><a href="#element-proxy-map">element proxy map</a><span>, in §5</span>
-   <li><a href="#frame-current">frame-current</a><span>, in §9</span>
-   <li><a href="#frame-requested">frame-requested</a><span>, in §9</span>
-   <li><a href="#input-property-list">input property list</a><span>, in §5</span>
-   <li><a href="#dom-elementproxy-inputstylemap">inputStyleMap</a><span>, in §8</span>
-   <li>
-    none
-    <ul>
-     <li><a href="#valdef-animator-root-none">value for animator-root</a><span>, in §12</span>
-     <li><a href="#valdef-animator-none">value for animator</a><span>, in §12</span>
-    </ul>
-   <li><a href="#output-property-list">output property list</a><span>, in §5</span>
-   <li><a href="#dom-elementproxy-outputstylemap">outputStyleMap</a><span>, in §8</span>
-   <li><a href="#parsing-an-animator-property-list">parsing an animator property list</a><span>, in §6</span>
-   <li><a href="#parsing-an-animator-slot-list">parsing an animator slot list</a><span>, in §6</span>
-   <li><a href="#parsing-an-animator-timeline-options-list">parsing an animator timeline options list</a><span>, in §6</span>
-   <li><a href="#proxied-element">proxied element</a><span>, in §5</span>
+   <li><a href="#create-a-new-animator-instance">create a new animator instance</a><span>, in §7.1</span>
+   <li><a href="#effect">effect</a><span>, in §5</span>
+   <li><a href="#frame-current">frame-current</a><span>, in §7.4</span>
+   <li><a href="#frame-requested">frame-requested</a><span>, in §7.4</span>
+   <li><a href="#global-execution-context">global execution context</a><span>, in §4</span>
    <li><a href="#dom-animationworkletglobalscope-registeranimator">registerAnimator(name, animatorCtor)</a><span>, in §6</span>
-   <li><a href="#root-element">root element</a><span>, in §5</span>
-   <li><a href="#run-animators">run animators</a><span>, in §10</span>
-   <li><a href="#slot-name">slot name</a><span>, in §5</span>
-   <li><a href="#update-proxy-input-style-map">update proxy input style map</a><span>, in §8</span>
+   <li><a href="#run-animators">run animators</a><span>, in §7.2</span>
+   <li><a href="#timeline">timeline</a><span>, in §5</span>
    <li><a href="#callbackdef-voidfunction">VoidFunction</a><span>, in §4</span>
+   <li><a href="#worklet-animation">worklet animation</a><span>, in §5</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-cascade-4/#computed-value">computed value</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[css-typed-om-1]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap">StylePropertyMap</a>
-     <li><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[css-values-3]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">*</a>
-     <li><a href="https://drafts.csswg.org/css-values-4/#comb-comma">,</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">&lt;ident></a>
-     <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
     </ul>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
@@ -2438,20 +2091,22 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
      <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#list">list</a>
+     <li><a href="https://infra.spec.whatwg.org/#struct">struct</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[web-animations-1]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/web-animations/#animation">Animation</a>
-     <li><a href="https://w3c.github.io/web-animations/#documenttimeline">DocumentTimeline</a>
-     <li><a href="https://w3c.github.io/web-animations/#dictdef-documenttimelineoptions">DocumentTimelineOptions</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
-     <li><a href="https://heycam.github.io/webidl/#NewObject">NewObject</a>
      <li><a href="https://heycam.github.io/webidl/#SameObject">SameObject</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
     </ul>
    <li>
     <a data-link-type="biblio">[worklets-1]</a> defines the following terms:
@@ -2464,16 +2119,14 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
-   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
-   <dt id="biblio-css-typed-om-1">[CSS-TYPED-OM-1]
-   <dd>Shane Stephens. <a href="https://www.w3.org/TR/css-typed-om-1/">CSS Typed OM Level 1</a>. URL: <a href="https://www.w3.org/TR/css-typed-om-1/">https://www.w3.org/TR/css-typed-om-1/</a>
    <dt id="biblio-css-values-3">[CSS-VALUES-3]
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
    <dt id="biblio-dom">[DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-web-animations-1">[WEB-ANIMATIONS-1]
@@ -2488,53 +2141,9 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
    <dt id="biblio-explainer">[EXPLAINER]
    <dd><a href="https://github.com/WICG/animation-worklet/blob/gh-pages/README.md">Animation Worklet Explainer</a>. CR. URL: <a href="https://github.com/WICG/animation-worklet/blob/gh-pages/README.md">https://github.com/WICG/animation-worklet/blob/gh-pages/README.md</a>
   </dl>
-  <h2 class="no-num no-ref heading settled" id="property-index"><span class="content">Property Index</span><a class="self-link" href="#property-index"></a></h2>
-  <div class="big-element-wrapper">
-   <table class="index">
-    <thead>
-     <tr>
-      <th scope="col">Name
-      <th scope="col">Value
-      <th scope="col">Initial
-      <th scope="col">Applies to
-      <th scope="col">Inh.
-      <th scope="col">%ages
-      <th scope="col">Media
-      <th scope="col">Ani­mat­able
-      <th scope="col">Canonical order
-      <th scope="col">Com­puted value
-    <tbody>
-     <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-animator">animator</a>
-      <td>none | [animator name animator slot, ]* animator name animator slot
-      <td>none
-      <td>all elements
-      <td>no
-      <td>N/A
-      <td>interactive
-      <td>no
-      <td>per grammar
-      <td>as specified
-     <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-animator-root">animator-root</a>
-      <td>none | [animator name animator slot, ]* animator name animator slot
-      <td>none
-      <td>all elements
-      <td>no
-      <td>N/A
-      <td>interactive
-      <td>no
-      <td>per grammar
-      <td>as specified
-   </table>
-  </div>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><span class="kt">interface</span> <a class="nv" href="#animationworklet"><code>AnimationWorklet</code></a> {
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv" href="#dom-animationworklet-addmodule"><code>addModule</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" href="#dom-animationworklet-addmodule-moduleurl-moduleurl"><code>moduleURL</code></a>);
-};
-
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a> {
-    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#animationworklet">AnimationWorklet</a> <a class="nv" data-readonly="" data-type="AnimationWorklet" href="#dom-window-animationworklet"><code>animationWorklet</code></a>;
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a> {
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/worklets/#worklet">Worklet</a> <a class="nv" data-readonly="" data-type="Worklet" href="#dom-window-animationworklet"><code>animationWorklet</code></a>;
 };
 
 <span class="kt">callback</span> <a class="nv" href="#callbackdef-voidfunction"><code>VoidFunction</code></a> = <span class="kt">void</span> ();
@@ -2544,31 +2153,26 @@ document<span class="p">.</span>animationWorklet<span class="p">.</span><span cl
     <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-animationworkletglobalscope-registeranimator">registerAnimator</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-name"><code>name</code></a>, <a class="n" data-link-type="idl-name" href="#callbackdef-voidfunction">VoidFunction</a> <a class="nv" href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor"><code>animatorCtor</code></a>);
 };
 
-[
-    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">AnimationWorklet</span>),
-] <span class="kt">interface</span> <a class="nv" href="#elementproxy"><code>ElementProxy</code></a> {
-    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a> <a class="nv" data-type="StylePropertyMapReadOnly" href="#dom-elementproxy-inputstylemap"><code>inputStyleMap</code></a>;
-    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">StylePropertyMapReadOnly</a> <a class="nv" data-type="StylePropertyMapReadOnly" href="#dom-elementproxy-outputstylemap"><code>outputStyleMap</code></a>;
-};
-
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> Todo: Should we have NoInterfaceObject/Exposed here? How do we properly represent that this
-cannot be constructed via javascript?<a href="#issue-65c145a8"> ↵ </a></div>
-   <div class="issue"> Give each animator instance a re-used set of AnimationTimelines instead of creating them
-       specifically here and when running animations.<a href="#issue-9b16e52a"> ↵ </a></div>
-   <div class="issue"> Need to add a definition for 'nearest non-visible overflow ancestor' to make sure all mentions
-       stay in sync.<a href="#issue-a9c8649c"> ↵ </a></div>
-   <div class="issue"> Consider giving user agents permission to skip running animator instances to throttle
-    slow animators.<a href="#issue-dc52329c"> ↵ </a></div>
-   <div class="issue"> Todo: Define when we may get rid of the animator.<a href="#issue-d4d8f39c"> ↵ </a></div>
-   <div class="issue"> Todo: the animators output style values have the highest order in animation stack effect and
-their composite operation is "replace" which is going to allow them to run independent on other
-animations and in a different thread. Supporting other composite operation is not in scope at this
-point.<a href="#issue-b3b90f2d"> ↵ </a></div>
+   <div class="issue"> This is no longer true as we provide destroy callback.<a href="#issue-8ecade61"> ↵ </a></div>
+   <div class="issue"> Consider giving user agents permission to skip running animator instances to
+    throttle slow animators.<a href="#issue-07876098"> ↵ </a></div>
+   <div class="issue"> Define when we may get rid of the animator.<a href="#issue-216cac5b"> ↵ </a></div>
+   <div class="issue"> describe how constructor handles single or sequence of effects
+Issue(63): define new semantics for reverse/finish/playbackRate<a href="#issue-c2cb2c27"> ↵ </a></div>
+   <div class="issue"> Define semantics of attachment and detachment<a href="#issue-8cedaea7"> ↵ </a></div>
+   <div class="issue"> Worklet animations will have a special animation class that  ranks them with the highest
+order in animation stack effect. also their composite operation is "replace" which is going to
+allow them to run in parallel to other web animations in the system. Supporting other
+composite operation is not in scope at this point.<a href="#issue-8d2c2dd1"> ↵ </a></div>
    <div class="issue"> Need to decide what security considerations there are for this spec.<a href="#issue-de770110"> ↵ </a></div>
    <div class="issue"> Need to decide what privacy considerations there are for this spec.<a href="#issue-19f9ed9b"> ↵ </a></div>
+   <div class="issue"> This example uses a hypothetical <a class="property" data-link-type="propdesc">phase</a> property on timeline as a way to detect when user
+is no longer actively scrolling. This is a reasonable thing to have on scroll timeline. A simple
+fallback can emulate this by detecting when timeline time (i.e. scroll offset) has not changed in
+the last few frames.<a href="#issue-e1ad2274"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="animation-worklet">
    <b><a href="#animation-worklet">#animation-worklet</a></b><b>Referenced in:</b>
@@ -2577,16 +2181,10 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
     <li><a href="#ref-for-animation-worklet-3">3. Threading Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationworklet">
-   <b><a href="#animationworklet">#animationworklet</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animationworklet-1">4. Animation Worklet</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-window-animationworklet">
    <b><a href="#dom-window-animationworklet">#dom-window-animationworklet</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-window-animationworklet-1">4. Animation Worklet</a> <a href="#ref-for-dom-window-animationworklet-2">(2)</a>
+    <li><a href="#ref-for-dom-window-animationworklet-1">4. Animation Worklet</a> <a href="#ref-for-dom-window-animationworklet-2">(2)</a> <a href="#ref-for-dom-window-animationworklet-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="callbackdef-voidfunction">
@@ -2598,15 +2196,10 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
   <aside class="dfn-panel" data-for="animationworkletglobalscope">
    <b><a href="#animationworkletglobalscope">#animationworkletglobalscope</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-animationworkletglobalscope-1">4. Animation Worklet</a>
-    <li><a href="#ref-for-animationworkletglobalscope-2">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-animationworkletglobalscope-3">7. Creating an Animator</a> <a href="#ref-for-animationworkletglobalscope-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor">
-   <b><a href="#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor">#dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor-1">6. Registering an Animator Definition</a> <a href="#ref-for-dom-animationworkletglobalscope-registeranimator-name-animatorctor-animatorctor-2">(2)</a>
+    <li><a href="#ref-for-animationworkletglobalscope-1">4. Animation Worklet</a> <a href="#ref-for-animationworkletglobalscope-2">(2)</a>
+    <li><a href="#ref-for-animationworkletglobalscope-3">5. Concepts</a> <a href="#ref-for-animationworkletglobalscope-4">(2)</a>
+    <li><a href="#ref-for-animationworkletglobalscope-5">6. Registering an Animator Definition</a>
+    <li><a href="#ref-for-animationworkletglobalscope-6">7.1. Creating an Animator Instance</a> <a href="#ref-for-animationworkletglobalscope-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-definition">
@@ -2614,118 +2207,65 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-animator-definition-1">5. Concepts</a>
     <li><a href="#ref-for-animator-definition-2">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-animator-definition-3">12. CSS Animator Notation</a> <a href="#ref-for-animator-definition-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="animator-name">
+   <b><a href="#animator-name">#animator-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-animator-name-1">5. Concepts</a> <a href="#ref-for-animator-name-2">(2)</a>
+    <li><a href="#ref-for-animator-name-3">6. Registering an Animator Definition</a>
+    <li><a href="#ref-for-animator-name-4">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animator-name-5">7.2. Running Animators</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="class-constructor">
    <b><a href="#class-constructor">#class-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-class-constructor-1">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-class-constructor-2">7. Creating an Animator</a>
+    <li><a href="#ref-for-class-constructor-2">7.1. Creating an Animator Instance</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animate-function">
    <b><a href="#animate-function">#animate-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animate-function-1">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-animate-function-2">10. Running Animators</a>
-    <li><a href="#ref-for-animate-function-3">12. CSS Animator Notation</a> <a href="#ref-for-animate-function-4">(2)</a> <a href="#ref-for-animate-function-5">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="animator-slot-list">
-   <b><a href="#animator-slot-list">#animator-slot-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animator-slot-list-1">5. Concepts</a>
-    <li><a href="#ref-for-animator-slot-list-2">8. Creating an Element Proxy</a>
-    <li><a href="#ref-for-animator-slot-list-3">9.2. Change in an element’s computed style</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="animator-timeline-options-list">
-   <b><a href="#animator-timeline-options-list">#animator-timeline-options-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animator-timeline-options-list-1">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-animator-timeline-options-list-2">9.3. Animator specifies a DocumentTimeline</a>
-    <li><a href="#ref-for-animator-timeline-options-list-3">9.4. Animator specifies a ScrollTimeline</a> <a href="#ref-for-animator-timeline-options-list-4">(2)</a>
-    <li><a href="#ref-for-animator-timeline-options-list-5">10. Running Animators</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="animator-slot">
-   <b><a href="#animator-slot">#animator-slot</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animator-slot-1">5. Concepts</a>
-    <li><a href="#ref-for-animator-slot-2">12. CSS Animator Notation</a> <a href="#ref-for-animator-slot-3">(2)</a> <a href="#ref-for-animator-slot-4">(3)</a> <a href="#ref-for-animator-slot-5">(4)</a> <a href="#ref-for-animator-slot-6">(5)</a> <a href="#ref-for-animator-slot-7">(6)</a> <a href="#ref-for-animator-slot-8">(7)</a> <a href="#ref-for-animator-slot-9">(8)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="animator-input-property-list">
-   <b><a href="#animator-input-property-list">#animator-input-property-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animator-input-property-list-1">8. Creating an Element Proxy</a>
-    <li><a href="#ref-for-animator-input-property-list-2">9.2. Change in an element’s computed style</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="animator-output-property-list">
-   <b><a href="#animator-output-property-list">#animator-output-property-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-animator-output-property-list-1">8. Creating an Element Proxy</a>
+    <li><a href="#ref-for-animate-function-2">7.2. Running Animators</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-instance">
    <b><a href="#animator-instance">#animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-instance-1">5. Concepts</a> <a href="#ref-for-animator-instance-2">(2)</a>
-    <li><a href="#ref-for-animator-instance-3">7. Creating an Animator</a> <a href="#ref-for-animator-instance-4">(2)</a> <a href="#ref-for-animator-instance-5">(3)</a>
-    <li><a href="#ref-for-animator-instance-6">8. Creating an Element Proxy</a> <a href="#ref-for-animator-instance-7">(2)</a> <a href="#ref-for-animator-instance-8">(3)</a>
-    <li><a href="#ref-for-animator-instance-9">9. Requesting Animation Frames</a>
-    <li><a href="#ref-for-animator-instance-10">9.1. Element proxy creation/removal</a> <a href="#ref-for-animator-instance-11">(2)</a>
-    <li><a href="#ref-for-animator-instance-12">10. Running Animators</a>
-    <li><a href="#ref-for-animator-instance-13">12. CSS Animator Notation</a> <a href="#ref-for-animator-instance-14">(2)</a> <a href="#ref-for-animator-instance-15">(3)</a> <a href="#ref-for-animator-instance-16">(4)</a> <a href="#ref-for-animator-instance-17">(5)</a>
+    <li><a href="#ref-for-animator-instance-3">7.1. Creating an Animator Instance</a> <a href="#ref-for-animator-instance-4">(2)</a> <a href="#ref-for-animator-instance-5">(3)</a>
+    <li><a href="#ref-for-animator-instance-6">7.2. Running Animators</a>
+    <li><a href="#ref-for-animator-instance-7">7.4. Requesting Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-name">
-   <b><a href="#animator-name">#animator-name</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="animator-output-effect">
+   <b><a href="#animator-output-effect">#animator-output-effect</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-animator-name-1">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-animator-name-2">7. Creating an Animator</a>
-    <li><a href="#ref-for-animator-name-3">12. CSS Animator Notation</a> <a href="#ref-for-animator-name-4">(2)</a> <a href="#ref-for-animator-name-5">(3)</a> <a href="#ref-for-animator-name-6">(4)</a> <a href="#ref-for-animator-name-7">(5)</a> <a href="#ref-for-animator-name-8">(6)</a> <a href="#ref-for-animator-name-9">(7)</a> <a href="#ref-for-animator-name-10">(8)</a> <a href="#ref-for-animator-name-11">(9)</a> <a href="#ref-for-animator-name-12">(10)</a> <a href="#ref-for-animator-name-13">(11)</a> <a href="#ref-for-animator-name-14">(12)</a> <a href="#ref-for-animator-name-15">(13)</a> <a href="#ref-for-animator-name-16">(14)</a> <a href="#ref-for-animator-name-17">(15)</a> <a href="#ref-for-animator-name-18">(16)</a> <a href="#ref-for-animator-name-19">(17)</a>
+    <li><a href="#ref-for-animator-output-effect-1">7.1. Creating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root-element">
-   <b><a href="#root-element">#root-element</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="animator-timelines-list">
+   <b><a href="#animator-timelines-list">#animator-timelines-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-root-element-1">9.4. Animator specifies a ScrollTimeline</a> <a href="#ref-for-root-element-2">(2)</a>
-    <li><a href="#ref-for-root-element-3">12. CSS Animator Notation</a> <a href="#ref-for-root-element-4">(2)</a> <a href="#ref-for-root-element-5">(3)</a>
+    <li><a href="#ref-for-animator-timelines-list-1">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animator-timelines-list-2">7.4. Requesting Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-proxy-map">
-   <b><a href="#element-proxy-map">#element-proxy-map</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="timeline">
+   <b><a href="#timeline">#timeline</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-element-proxy-map-1">6. Registering an Animator Definition</a>
-    <li><a href="#ref-for-element-proxy-map-2">10. Running Animators</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="element-proxy">
-   <b><a href="#element-proxy">#element-proxy</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-element-proxy-1">5. Concepts</a>
-    <li><a href="#ref-for-element-proxy-2">8. Creating an Element Proxy</a> <a href="#ref-for-element-proxy-3">(2)</a>
-    <li><a href="#ref-for-element-proxy-4">9.2. Change in an element’s computed style</a> <a href="#ref-for-element-proxy-5">(2)</a>
-    <li><a href="#ref-for-element-proxy-6">12. CSS Animator Notation</a> <a href="#ref-for-element-proxy-7">(2)</a> <a href="#ref-for-element-proxy-8">(3)</a> <a href="#ref-for-element-proxy-9">(4)</a> <a href="#ref-for-element-proxy-10">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="proxied-element">
-   <b><a href="#proxied-element">#proxied-element</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-proxied-element-1">8. Creating an Element Proxy</a> <a href="#ref-for-proxied-element-2">(2)</a> <a href="#ref-for-proxied-element-3">(3)</a> <a href="#ref-for-proxied-element-4">(4)</a>
+    <li><a href="#ref-for-timeline-1">5. Concepts</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animator-name-to-animator-definition-map">
    <b><a href="#animator-name-to-animator-definition-map">#animator-name-to-animator-definition-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-name-to-animator-definition-map-1">6. Registering an Animator Definition</a> <a href="#ref-for-animator-name-to-animator-definition-map-2">(2)</a>
-    <li><a href="#ref-for-animator-name-to-animator-definition-map-3">7. Creating an Animator</a>
-    <li><a href="#ref-for-animator-name-to-animator-definition-map-4">8. Creating an Element Proxy</a>
-    <li><a href="#ref-for-animator-name-to-animator-definition-map-5">9.2. Change in an element’s computed style</a>
-    <li><a href="#ref-for-animator-name-to-animator-definition-map-6">10. Running Animators</a>
+    <li><a href="#ref-for-animator-name-to-animator-definition-map-3">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animator-name-to-animator-definition-map-4">7.2. Running Animators</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-animationworkletglobalscope-registeranimator">
@@ -2735,105 +2275,40 @@ point.<a href="#issue-b3b90f2d"> ↵ </a></div>
     <li><a href="#ref-for-dom-animationworkletglobalscope-registeranimator-2">6. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-an-animator-slot-list">
-   <b><a href="#parsing-an-animator-slot-list">#parsing-an-animator-slot-list</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="animation-id-to-instance-map">
+   <b><a href="#animation-id-to-instance-map">#animation-id-to-instance-map</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsing-an-animator-slot-list-1">6. Registering an Animator Definition</a>
+    <li><a href="#ref-for-animation-id-to-instance-map-1">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animation-id-to-instance-map-2">7.2. Running Animators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-an-animator-property-list">
-   <b><a href="#parsing-an-animator-property-list">#parsing-an-animator-property-list</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="run-animators">
+   <b><a href="#run-animators">#run-animators</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsing-an-animator-property-list-1">6. Registering an Animator Definition</a> <a href="#ref-for-parsing-an-animator-property-list-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="parsing-an-animator-timeline-options-list">
-   <b><a href="#parsing-an-animator-timeline-options-list">#parsing-an-animator-timeline-options-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parsing-an-animator-timeline-options-list-1">6. Registering an Animator Definition</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="-animator-name-root-element-to-instance-map">
-   <b><a href="#-animator-name-root-element-to-instance-map">#-animator-name-root-element-to-instance-map</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for--animator-name-root-element-to-instance-map-1">7. Creating an Animator</a>
-    <li><a href="#ref-for--animator-name-root-element-to-instance-map-2">10. Running Animators</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="create-a-new-animator-instance">
-   <b><a href="#create-a-new-animator-instance">#create-a-new-animator-instance</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-create-a-new-animator-instance-1">10. Running Animators</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="elementproxy">
-   <b><a href="#elementproxy">#elementproxy</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-elementproxy-1">8. Creating an Element Proxy</a> <a href="#ref-for-elementproxy-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-elementproxy-outputstylemap">
-   <b><a href="#dom-elementproxy-outputstylemap">#dom-elementproxy-outputstylemap</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-elementproxy-outputstylemap-1">8. Creating an Element Proxy</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="update-proxy-input-style-map">
-   <b><a href="#update-proxy-input-style-map">#update-proxy-input-style-map</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-update-proxy-input-style-map-1">8. Creating an Element Proxy</a>
+    <li><a href="#ref-for-run-animators-1">7.2. Running Animators</a> <a href="#ref-for-run-animators-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="animation-requested-flag">
    <b><a href="#animation-requested-flag">#animation-requested-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-requested-flag-1">5. Concepts</a>
-    <li><a href="#ref-for-animation-requested-flag-2">7. Creating an Animator</a>
-    <li><a href="#ref-for-animation-requested-flag-3">9. Requesting Animation Frames</a> <a href="#ref-for-animation-requested-flag-4">(2)</a>
-    <li><a href="#ref-for-animation-requested-flag-5">9.1. Element proxy creation/removal</a>
-    <li><a href="#ref-for-animation-requested-flag-6">9.2. Change in an element’s computed style</a>
-    <li><a href="#ref-for-animation-requested-flag-7">9.3. Animator specifies a DocumentTimeline</a>
-    <li><a href="#ref-for-animation-requested-flag-8">9.4. Animator specifies a ScrollTimeline</a>
-    <li><a href="#ref-for-animation-requested-flag-9">10. Running Animators</a> <a href="#ref-for-animation-requested-flag-10">(2)</a>
+    <li><a href="#ref-for-animation-requested-flag-2">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-animation-requested-flag-3">7.2. Running Animators</a> <a href="#ref-for-animation-requested-flag-4">(2)</a>
+    <li><a href="#ref-for-animation-requested-flag-5">7.4. Requesting Animation Frames</a> <a href="#ref-for-animation-requested-flag-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="frame-requested">
    <b><a href="#frame-requested">#frame-requested</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-frame-requested-1">9. Requesting Animation Frames</a>
-    <li><a href="#ref-for-frame-requested-2">9.1. Element proxy creation/removal</a>
-    <li><a href="#ref-for-frame-requested-3">9.2. Change in an element’s computed style</a>
-    <li><a href="#ref-for-frame-requested-4">9.3. Animator specifies a DocumentTimeline</a>
-    <li><a href="#ref-for-frame-requested-5">9.4. Animator specifies a ScrollTimeline</a>
-    <li><a href="#ref-for-frame-requested-6">10. Running Animators</a>
+    <li><a href="#ref-for-frame-requested-1">7.2. Running Animators</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="frame-current">
    <b><a href="#frame-current">#frame-current</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-frame-current-1">7. Creating an Animator</a>
-    <li><a href="#ref-for-frame-current-2">9. Requesting Animation Frames</a> <a href="#ref-for-frame-current-3">(2)</a>
-    <li><a href="#ref-for-frame-current-4">10. Running Animators</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="run-animators">
-   <b><a href="#run-animators">#run-animators</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-run-animators-1">10. Running Animators</a> <a href="#ref-for-run-animators-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="propdef-animator-root">
-   <b><a href="#propdef-animator-root">#propdef-animator-root</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-propdef-animator-root-1">8. Creating an Element Proxy</a>
-    <li><a href="#ref-for-propdef-animator-root-2">12. CSS Animator Notation</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="propdef-animator">
-   <b><a href="#propdef-animator">#propdef-animator</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-propdef-animator-1">8. Creating an Element Proxy</a>
-    <li><a href="#ref-for-propdef-animator-2">12. CSS Animator Notation</a>
+    <li><a href="#ref-for-frame-current-1">7.1. Creating an Animator Instance</a>
+    <li><a href="#ref-for-frame-current-2">7.2. Running Animators</a>
+    <li><a href="#ref-for-frame-current-3">7.4. Requesting Animation Frames</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This is a pretty large patch. It is a major rewrites of most of the spec including the following 
changes:
- Remove any deprecated info
- Add structure to support the new specification with appropriate TODO notes for missing information
- Update Animator Definition and Animation concepts to match the new design
- Update Animation Definition registration and Animator Instance creation/running algorithms.
- Update all example using the EXPLAINER syntax

I will follow up this with other patches that will replace TODO with more accurate descriptions.